### PR TITLE
feat: Auto Import of Existing Catalyst Servers on Node

### DIFF
--- a/catalyst-agent/Cargo.lock
+++ b/catalyst-agent/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "catalyst-agent"
-version = "1.1.15"
+version = "1.1.16"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/catalyst-agent/src/runtime_manager.rs
+++ b/catalyst-agent/src/runtime_manager.rs
@@ -367,6 +367,8 @@ pub struct ContainerInspectInfo {
     pub memory_limit_bytes: i64,
     pub cpu_quota: i64,
     pub cpu_period: i64,
+    pub startup_command: String,    // process.args joined as string
+    pub env_var_names: Vec<String>, // env var NAMES only (not values, for security)
 }
 
 #[derive(Debug)]
@@ -1555,6 +1557,32 @@ impl ContainerdRuntime {
                         .and_then(|p| p.as_i64())
                     {
                         info.cpu_period = period;
+                    }
+
+                    // Startup command (process.args)
+                    if let Some(args) = spec_value
+                        .get("process")
+                        .and_then(|p| p.get("args"))
+                        .and_then(|a| a.as_array())
+                    {
+                        let arg_strings: Vec<String> = args
+                            .iter()
+                            .filter_map(|a| a.as_str().map(String::from))
+                            .collect();
+                        info.startup_command = arg_strings.join(" ");
+                    }
+
+                    // Environment variable NAMES only (not values — may contain secrets)
+                    if let Some(env_list) = spec_value
+                        .get("process")
+                        .and_then(|p| p.get("env"))
+                        .and_then(|e| e.as_array())
+                    {
+                        info.env_var_names = env_list
+                            .iter()
+                            .filter_map(|e| e.as_str())
+                            .filter_map(|entry| entry.split_once('=').map(|(k, _)| k.to_string()))
+                            .collect();
                     }
                 }
             }

--- a/catalyst-agent/src/runtime_manager.rs
+++ b/catalyst-agent/src/runtime_manager.rs
@@ -357,6 +357,7 @@ pub struct ContainerInfo {
     pub status: String,
     pub command: String,
     pub image: String,
+    pub labels: HashMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -1450,6 +1451,7 @@ impl ContainerdRuntime {
                 },
                 image: c.image.clone(),
                 command: String::new(),
+                labels: c.labels.clone(),
             });
         }
 

--- a/catalyst-agent/src/runtime_manager.rs
+++ b/catalyst-agent/src/runtime_manager.rs
@@ -360,6 +360,15 @@ pub struct ContainerInfo {
     pub labels: HashMap<String, String>,
 }
 
+/// Inspected OCI-derived configuration from an existing container.
+#[derive(Debug, Clone, Default)]
+pub struct ContainerInspectInfo {
+    pub network_mode: String, // "host" or "bridge"
+    pub memory_limit_bytes: i64,
+    pub cpu_quota: i64,
+    pub cpu_period: i64,
+}
+
 #[derive(Debug)]
 pub struct ContainerStats {
     pub container_id: String,
@@ -1472,6 +1481,86 @@ impl ContainerdRuntime {
             tokio::time::timeout(Duration::from_secs(5), client.get(req)).await,
             Ok(Ok(_))
         )
+    }
+
+    /// Inspect an existing container and extract its OCI-derived config
+    /// (network mode, memory limits, CPU allocation). This is used by the
+    /// auto-import feature so the backend can recreate the server record
+    /// with the same resource profile.
+    pub async fn inspect_container(
+        &self,
+        container_id: &str,
+    ) -> AgentResult<Option<ContainerInspectInfo>> {
+        let mut client = ContainersClient::new(self.channel.clone());
+        let req = GetContainerRequest {
+            id: container_id.to_string(),
+        };
+        let req = with_namespace!(req, &self.namespace);
+        let resp = tokio::time::timeout(Duration::from_secs(5), client.get(req))
+            .await
+            .map_err(|_| AgentError::ContainerError("inspect_container timed out".to_string()))?
+            .map_err(grpc_err)?;
+
+        let container = resp.into_inner().container;
+        let Some(container) = container else {
+            return Ok(None);
+        };
+
+        let mut info = ContainerInspectInfo::default();
+
+        // Parse OCI spec to extract network mode and resource limits
+        if let Some(spec_any) = container.spec {
+            if spec_any.type_url == SPEC_TYPE_URL {
+                if let Ok(spec_value) = serde_json::from_slice::<serde_json::Value>(&spec_any.value)
+                {
+                    // Network mode: absence of "network" namespace = host networking
+                    if let Some(namespaces) = spec_value
+                        .get("linux")
+                        .and_then(|l| l.get("namespaces"))
+                        .and_then(|n| n.as_array())
+                    {
+                        let has_network_ns = namespaces
+                            .iter()
+                            .any(|ns| ns.get("type").and_then(|t| t.as_str()) == Some("network"));
+                        info.network_mode =
+                            if has_network_ns { "bridge" } else { "host" }.to_string();
+                    }
+
+                    // Memory limit (bytes)
+                    if let Some(limit) = spec_value
+                        .get("linux")
+                        .and_then(|l| l.get("resources"))
+                        .and_then(|r| r.get("memory"))
+                        .and_then(|m| m.get("limit"))
+                        .and_then(|l| l.as_i64())
+                    {
+                        info.memory_limit_bytes = limit;
+                    }
+
+                    // CPU quota and period
+                    if let Some(quota) = spec_value
+                        .get("linux")
+                        .and_then(|l| l.get("resources"))
+                        .and_then(|r| r.get("cpu"))
+                        .and_then(|c| c.get("quota"))
+                        .and_then(|q| q.as_i64())
+                    {
+                        info.cpu_quota = quota;
+                    }
+                    if let Some(period) = spec_value
+                        .get("linux")
+                        .and_then(|l| l.get("resources"))
+                        .and_then(|r| r.get("cpu"))
+                        .and_then(|c| c.get("period"))
+                        .and_then(|p| p.as_i64())
+                    {
+                        info.cpu_period = period;
+                    }
+                }
+            }
+        }
+
+        Ok(Some(info))
     }
 
     pub async fn is_container_running(&self, container_id: &str) -> AgentResult<bool> {

--- a/catalyst-agent/src/websocket_handler.rs
+++ b/catalyst-agent/src/websocket_handler.rs
@@ -151,6 +151,25 @@ struct ServerStateSync<'a> {
     timestamp: i64,
 }
 
+#[derive(serde::Serialize)]
+#[allow(non_snake_case)]
+struct DiscoveredServer<'a> {
+    containerId: &'a str,
+    image: &'a str,
+    status: &'a str,
+    labels: &'a HashMap<String, String>,
+}
+
+#[derive(serde::Serialize)]
+#[allow(non_snake_case)]
+struct DiscoveredServers<'a> {
+    #[serde(rename = "type")]
+    ty: &'static str,
+    nodeId: &'a str,
+    containers: Vec<DiscoveredServer<'a>>,
+    timestamp: i64,
+}
+
 /// Shell-escape a value for safe interpolation into a bash script.
 /// Wraps the value in single quotes and escapes any embedded single quotes.
 fn shell_escape_value(value: &str) -> String {
@@ -4847,7 +4866,7 @@ impl WebSocketHandler {
         }
 
         // Report state for all known containers
-        for container in containers {
+        for container in &containers {
             if !container.managed {
                 continue;
             }
@@ -4921,6 +4940,32 @@ impl WebSocketHandler {
         let mut w = ws.lock().await;
         if let Err(err) = w.send(Message::Text(complete_text.into())).await {
             warn!("Failed to send reconciliation complete: {}", err);
+        }
+
+        // Send discovered containers info for auto-import feature
+        let discovered: Vec<DiscoveredServer> = containers
+            .iter()
+            .filter(|c| c.managed)
+            .map(|c| DiscoveredServer {
+                containerId: &c.id,
+                image: &c.image,
+                status: &c.status,
+                labels: &c.labels,
+            })
+            .collect();
+
+        if !discovered.is_empty() {
+            let discovered_msg = DiscoveredServers {
+                ty: "discovered_servers",
+                nodeId: &self.config.server.node_id,
+                containers: discovered,
+                timestamp: chrono::Utc::now().timestamp_millis(),
+            };
+            let discovered_text = serde_json::to_string(&discovered_msg).unwrap_or_default();
+
+            if let Err(err) = w.send(Message::Text(discovered_text.into())).await {
+                warn!("Failed to send discovered servers: {}", err);
+            }
         }
 
         info!(

--- a/catalyst-agent/src/websocket_handler.rs
+++ b/catalyst-agent/src/websocket_handler.rs
@@ -164,6 +164,10 @@ struct DiscoveredServer<'a> {
     memoryLimitMb: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cpuCores: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    startupCommand: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    envVarNames: Vec<String>,
 }
 
 #[derive(serde::Serialize)]
@@ -4972,6 +4976,14 @@ impl WebSocketHandler {
                         None
                     }
                 }),
+                startupCommand: inspect
+                    .as_ref()
+                    .map(|i| i.startup_command.clone())
+                    .filter(|s| !s.is_empty()),
+                envVarNames: inspect
+                    .as_ref()
+                    .map(|i| i.env_var_names.clone())
+                    .unwrap_or_default(),
             });
         }
 

--- a/catalyst-agent/src/websocket_handler.rs
+++ b/catalyst-agent/src/websocket_handler.rs
@@ -158,6 +158,12 @@ struct DiscoveredServer<'a> {
     image: &'a str,
     status: &'a str,
     labels: &'a HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    networkMode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memoryLimitMb: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cpuCores: Option<u64>,
 }
 
 #[derive(serde::Serialize)]
@@ -4943,16 +4949,31 @@ impl WebSocketHandler {
         }
 
         // Send discovered containers info for auto-import feature
-        let discovered: Vec<DiscoveredServer> = containers
-            .iter()
-            .filter(|c| c.managed)
-            .map(|c| DiscoveredServer {
+        let mut discovered = Vec::new();
+        for c in containers.iter().filter(|c| c.managed) {
+            let inspect = self.runtime.inspect_container(&c.id).await.ok().flatten();
+            discovered.push(DiscoveredServer {
                 containerId: &c.id,
                 image: &c.image,
                 status: &c.status,
                 labels: &c.labels,
-            })
-            .collect();
+                networkMode: inspect.as_ref().map(|i| i.network_mode.clone()),
+                memoryLimitMb: inspect.as_ref().and_then(|i| {
+                    if i.memory_limit_bytes > 0 {
+                        Some((i.memory_limit_bytes as u64) / (1024 * 1024))
+                    } else {
+                        None
+                    }
+                }),
+                cpuCores: inspect.as_ref().and_then(|i| {
+                    if i.cpu_quota > 0 && i.cpu_period > 0 {
+                        Some((i.cpu_quota as u64) / (i.cpu_period as u64))
+                    } else {
+                        None
+                    }
+                }),
+            });
+        }
 
         if !discovered.is_empty() {
             let discovered_msg = DiscoveredServers {

--- a/catalyst-backend/src/routes/nodes.ts
+++ b/catalyst-backend/src/routes/nodes.ts
@@ -1673,10 +1673,143 @@ export async function nodeRoutes(app: FastifyInstance) {
 					networkMode: c.networkMode,
 					memoryLimitMb: c.memoryLimitMb,
 					cpuCores: c.cpuCores,
+					startupCommand: c.startupCommand,
+					envVarNames: c.envVarNames,
 					discoveredAt: c.discoveredAt,
 				}));
 
 			reply.send({ success: true, data: unregistered });
+		},
+	);
+
+	// Suggest template match for an unregistered container
+	app.get(
+		"/:nodeId/unregistered-containers/:containerId/suggest-template",
+		{ onRequest: [app.authenticate] },
+		async (request: FastifyRequest, reply: FastifyReply) => {
+			if (!ensurePermission(request, reply, "admin.write")) return;
+			const { nodeId, containerId } = request.params as { nodeId: string; containerId: string };
+
+			// Verify node exists
+			const node = await prisma.node.findUnique({
+				where: { id: nodeId },
+				select: { id: true },
+			});
+			if (!node) {
+				return reply.status(404).send({ error: "Node not found" });
+			}
+
+			const wsGateway = (app as any).wsGateway;
+			const discovered = wsGateway?.getDiscoveredContainers?.(nodeId) ?? [];
+			const container = discovered.find((c: any) => c.containerId === containerId);
+			if (!container) {
+				return reply.status(404).send({ error: "Container not found" });
+			}
+
+			// Fetch all templates to match against
+			const templates = await prisma.serverTemplate.findMany({
+				select: {
+					id: true,
+					name: true,
+					startup: true,
+					variables: true,
+					image: true,
+					images: true,
+				},
+			});
+
+			// Score each template based on matching signals
+			const results = templates.map((template) => {
+				let score = 0;
+				const matchReasons: string[] = [];
+
+				// 1. Match startup command pattern
+				if (container.startupCommand && template.startup) {
+					const templateStartup = template.startup.toLowerCase();
+					const containerStartup = container.startupCommand.toLowerCase();
+
+					// Extract structural parts of the template startup (non-variable tokens)
+					const structuralTokens = templateStartup
+						.split(/[\s]+/)
+						.filter((t) => !t.startsWith("{{"))
+						.filter((t) => t.length > 1);
+
+					let matchedTokens = 0;
+					for (const token of structuralTokens) {
+						if (containerStartup.includes(token)) {
+							matchedTokens++;
+						}
+					}
+					if (structuralTokens.length > 0 && matchedTokens > 0) {
+						const tokenScore = matchedTokens / structuralTokens.length;
+						score += tokenScore * 50; // Up to 50 points for startup match
+						if (tokenScore > 0.5) {
+							matchReasons.push(`Startup command matches ${Math.round(tokenScore * 100)}%`);
+						}
+					}
+				}
+
+				// 2. Match env var names
+				if (container.envVarNames && container.envVarNames.length > 0) {
+					const templateVars = (template.variables as any[]) || [];
+					const templateVarNames = new Set(
+						templateVars.map((v: any) => v?.name).filter(Boolean),
+					);
+
+					if (templateVarNames.size > 0) {
+						let matchedVars = 0;
+						for (const varName of templateVarNames) {
+							if (container.envVarNames.includes(varName)) {
+								matchedVars++;
+							}
+						}
+						if (matchedVars > 0) {
+							const varScore = matchedVars / templateVarNames.size;
+							score += varScore * 30; // Up to 30 points for env var match
+							if (varScore > 0.3) {
+								matchReasons.push(`${matchedVars}/${templateVarNames.size} env variables match`);
+							}
+						}
+					}
+				}
+
+				// 3. Match image name
+				if (container.image && template.image) {
+					const containerImage = container.image.toLowerCase();
+					const templateImages = [
+						template.image,
+						...((template.images as any[]) || []).map((i: any) => i?.image || ""),
+					].map((i) => i.toLowerCase());
+
+					for (const templateImage of templateImages) {
+						if (!templateImage) continue;
+						const containerRepoTag = containerImage.split(":")[0];
+						const templateRepoTag = templateImage.split(":")[0];
+						if (containerRepoTag === templateRepoTag) {
+							score += 20;
+							matchReasons.push(`Image matches: ${containerImage}`);
+							break;
+						}
+						if (containerRepoTag.includes(templateRepoTag) || templateRepoTag.includes(containerRepoTag)) {
+							score += 10;
+							matchReasons.push(`Image repo similar: ${containerImage}`);
+							break;
+						}
+					}
+				}
+
+				return {
+					templateId: template.id,
+					templateName: template.name,
+					score: Math.round(score),
+					matchReasons,
+				};
+			})
+				.filter((r) => r.score > 0)
+				.sort((a, b) => b.score - a.score)
+				.slice(0, 5); // Top 5 matches
+
+			reply.send({ success: true, data: results });
 		},
 	);
 

--- a/catalyst-backend/src/routes/nodes.ts
+++ b/catalyst-backend/src/routes/nodes.ts
@@ -1632,6 +1632,210 @@ export async function nodeRoutes(app: FastifyInstance) {
 	);
 
 	// ============================================================================
+	// AUTO-IMPORT: UNREGISTERED CONTAINERS
+	// ============================================================================
+
+	// Get unregistered containers discovered on a node (containers without DB server records)
+	app.get(
+		"/:nodeId/unregistered-containers",
+		{ onRequest: [app.authenticate] },
+		async (request: FastifyRequest, reply: FastifyReply) => {
+			if (!ensurePermission(request, reply, "admin.write")) return;
+			const { nodeId } = request.params as { nodeId: string };
+
+			const node = await prisma.node.findUnique({
+				where: { id: nodeId },
+				select: { id: true, locationId: true },
+			});
+			if (!node) {
+				return reply.status(404).send({ error: "Node not found" });
+			}
+
+			// Get registered server IDs for this node
+			const registeredServers = await prisma.server.findMany({
+				where: { nodeId },
+				select: { id: true },
+			});
+			const registeredIds = new Set(registeredServers.map((s) => s.id));
+
+			// Get discovered containers from gateway
+			const wsGateway = (app as any).wsGateway;
+			const discovered = wsGateway?.getDiscoveredContainers?.(nodeId) ?? [];
+
+			// Filter out containers that are already registered
+			const unregistered = discovered
+				.filter((c: any) => !registeredIds.has(c.containerId))
+				.map((c: any) => ({
+					containerId: c.containerId,
+					image: c.image,
+					status: c.status,
+					labels: c.labels,
+					discoveredAt: c.discoveredAt,
+				}));
+
+			reply.send({ success: true, data: unregistered });
+		},
+	);
+
+	// Import a discovered container as a server
+	app.post(
+		"/:nodeId/import-server",
+		{ onRequest: [app.authenticate] },
+		async (request: FastifyRequest, reply: FastifyReply) => {
+			if (!ensurePermission(request, reply, "admin.write")) return;
+			const { nodeId } = request.params as { nodeId: string };
+			const {
+				containerId,
+				name,
+				templateId,
+				ownerId,
+				allocatedMemoryMb,
+				allocatedCpuCores,
+				allocatedDiskMb,
+				primaryPort,
+				portBindings,
+				environment,
+			} = request.body as {
+				containerId: string;
+				name: string;
+				templateId: string;
+				ownerId: string;
+				allocatedMemoryMb?: number;
+				allocatedCpuCores?: number;
+				allocatedDiskMb?: number;
+				primaryPort?: number;
+				portBindings?: Record<number, number>;
+				environment?: Record<string, string>;
+			};
+
+			// Validate required fields
+			if (!containerId || !name || !templateId || !ownerId) {
+				return reply.status(400).send({ error: "containerId, name, templateId, and ownerId are required" });
+			}
+
+			// Validate node
+			const node = await prisma.node.findUnique({
+				where: { id: nodeId },
+				select: { id: true, locationId: true },
+			});
+			if (!node) {
+				return reply.status(404).send({ error: "Node not found" });
+			}
+
+			// Verify container was discovered on this node
+			const wsGateway = (app as any).wsGateway;
+			const discovered = wsGateway?.getDiscoveredContainers?.(nodeId) ?? [];
+			const container = discovered.find((c: any) => c.containerId === containerId);
+			if (!container) {
+				return reply.status(400).send({ error: "Container not found on node. Agent reconciliation may be needed." });
+			}
+
+			// Verify no existing server with this container ID
+			const existing = await prisma.server.findUnique({
+				where: { id: containerId },
+			});
+			if (existing) {
+				return reply.status(409).send({ error: "A server with this container ID already exists" });
+			}
+
+			// Validate template
+			const template = await prisma.serverTemplate.findUnique({
+				where: { id: templateId },
+			});
+			if (!template) {
+				return reply.status(404).send({ error: "Template not found" });
+			}
+
+			// Validate owner
+			const owner = await prisma.user.findUnique({
+				where: { id: ownerId },
+			});
+			if (!owner) {
+				return reply.status(404).send({ error: "Owner not found" });
+			}
+
+			// Resolve environment with template defaults
+			const templateVariables = (template.variables as any[]) || [];
+			const templateDefaults = templateVariables.reduce((acc: Record<string, string>, variable: any) => {
+				if (variable?.name && variable?.default !== undefined) {
+					acc[variable.name] = String(variable.default);
+				}
+				return acc;
+			}, {} as Record<string, string>);
+			const resolvedEnvironment = {
+				...templateDefaults,
+				...(environment || {}),
+			};
+
+			// Derive status from container
+			const status = container.status.includes("Up") ? "running" : "stopped";
+
+			// Create server record — containerId IS the server.id (critical for agent sync)
+			const server = await prisma.server.create({
+				data: {
+					id: containerId,                    // MUST match container name for agent sync
+					uuid: uuidv4(),
+					name,
+					templateId,
+					nodeId,
+					locationId: node.locationId,
+					ownerId,
+					status,
+					allocatedMemoryMb: allocatedMemoryMb ?? template.allocatedMemoryMb,
+					allocatedCpuCores: allocatedCpuCores ?? template.allocatedCpuCores,
+					allocatedDiskMb: allocatedDiskMb ?? 10240,
+					containerId,
+					containerName: containerId,
+					networkMode: "bridge",
+					primaryPort: primaryPort ?? 25565,
+					portBindings: portBindings ?? {},
+					environment: resolvedEnvironment,
+					startupCommand: template.startup,
+				},
+			});
+
+			// Create system log entry
+			await prisma.serverLog.create({
+				data: {
+					serverId: server.id,
+					stream: "system",
+					data: `[Import] Server imported from existing container ${containerId}`,
+				},
+			});
+
+			// Audit log
+			await prisma.auditLog.create({
+				data: {
+					userId: request.user.userId,
+					action: "server.import",
+					resource: "server",
+					resourceId: server.id,
+					details: {
+						containerId,
+						nodeId,
+						templateId,
+						ownerId,
+						source: "auto_import",
+					},
+				},
+			});
+
+			reply.status(201).send(serialize({ success: true, data: server }));
+
+			// Broadcast via WS
+			if (wsGateway?.pushToAdminSubscribers) {
+				wsGateway.pushToAdminSubscribers('server_created', {
+					type: 'server_created',
+					serverId: server.id,
+					nodeId,
+					ownerId,
+					timestamp: new Date().toISOString(),
+				});
+			}
+		},
+	);
+
+	// ============================================================================
 	// WILDCARD ASSIGNMENT ROUTE
 	// ============================================================================
 

--- a/catalyst-backend/src/routes/nodes.ts
+++ b/catalyst-backend/src/routes/nodes.ts
@@ -1670,6 +1670,9 @@ export async function nodeRoutes(app: FastifyInstance) {
 					image: c.image,
 					status: c.status,
 					labels: c.labels,
+					networkMode: c.networkMode,
+					memoryLimitMb: c.memoryLimitMb,
+					cpuCores: c.cpuCores,
 					discoveredAt: c.discoveredAt,
 				}));
 
@@ -1770,6 +1773,10 @@ export async function nodeRoutes(app: FastifyInstance) {
 			// Derive status from container
 			const status = container.status.includes("Up") ? "running" : "stopped";
 
+			// Use discovered resource defaults if user didn't specify values
+			const resolvedMemoryMb = allocatedMemoryMb ?? container.memoryLimitMb ?? template.allocatedMemoryMb;
+			const resolvedCpuCores = allocatedCpuCores ?? (container.cpuCores ? Math.ceil(container.cpuCores) : undefined) ?? template.allocatedCpuCores;
+
 			// Create server record — containerId IS the server.id (critical for agent sync)
 			const server = await prisma.server.create({
 				data: {
@@ -1781,12 +1788,12 @@ export async function nodeRoutes(app: FastifyInstance) {
 					locationId: node.locationId,
 					ownerId,
 					status,
-					allocatedMemoryMb: allocatedMemoryMb ?? template.allocatedMemoryMb,
-					allocatedCpuCores: allocatedCpuCores ?? template.allocatedCpuCores,
+					allocatedMemoryMb: resolvedMemoryMb,
+					allocatedCpuCores: resolvedCpuCores,
 					allocatedDiskMb: allocatedDiskMb ?? 10240,
 					containerId,
 					containerName: containerId,
-					networkMode: "bridge",
+					networkMode: container.networkMode || "bridge",
 					primaryPort: primaryPort ?? 25565,
 					portBindings: portBindings ?? {},
 					environment: resolvedEnvironment,

--- a/catalyst-backend/src/websocket/gateway.ts
+++ b/catalyst-backend/src/websocket/gateway.ts
@@ -160,6 +160,14 @@ export class WebSocketGateway {
   private readonly globalSseSubscribers = new Map<string, { eventTypes: string[]; push: (event: string, data: any) => void; serverIds?: Set<string>; lastActivity: number }>();
   // Admin SSE event subscribers — receive entity-level admin events (users, nodes, templates, alerts)
   private readonly adminEventSubscribers = new Map<string, { eventTypes: string[]; push: (event: string, data: any) => void; lastActivity: number }>();
+  // Discovered containers on nodes (for auto-import of existing servers)
+  private discoveredContainers = new Map<string, Array<{
+    containerId: string;
+    image: string;
+    status: string;
+    labels: Record<string, string>;
+    discoveredAt: number;
+  }>>();
 
   // ── Agent auth lockout tracker (progressive backoff) ───────────────────────
   // Tracks failed auth attempts per nodeId. Lockout durations increase with
@@ -303,6 +311,7 @@ export class WebSocketGateway {
           return;
         }
         this.agents.delete(nodeId);
+        this.discoveredContainers.delete(nodeId);
         this.prisma.node.update({
           where: { id: nodeId },
           data: { isOnline: false },
@@ -1461,6 +1470,18 @@ export class WebSocketGateway {
 
         if (!server) {
           this.logger.warn(`State sync for unknown server ID: ${message.serverUuid}`);
+          // Track as unregistered container for auto-import
+          const existing = this.discoveredContainers.get(nodeId) ?? [];
+          if (!existing.some(c => c.containerId === message.serverUuid)) {
+            existing.push({
+              containerId: message.serverUuid,
+              image: "",
+              status: message.state === "running" ? "Up" : "Exited",
+              labels: {},
+              discoveredAt: Date.now(),
+            });
+            this.discoveredContainers.set(nodeId, existing);
+          }
           return;
         }
         if (server.nodeId !== nodeId) {
@@ -1783,6 +1804,25 @@ export class WebSocketGateway {
         await this.routeToClients(message.serverId, message);
       } else if (message.type === "storage_resize_complete") {
         await this.routeToClients(message.serverId, message);
+      } else if (message.type === "discovered_servers") {
+        if (!message.nodeId || message.nodeId !== nodeId) {
+          this.logger.warn({ nodeId, messageNodeId: message.nodeId }, "discovered_servers node mismatch");
+          return;
+        }
+        const containers = Array.isArray(message.containers) ? message.containers : [];
+
+        this.discoveredContainers.set(nodeId, containers.map((c: any) => ({
+          containerId: String(c.containerId || ""),
+          image: String(c.image || ""),
+          status: String(c.status || ""),
+          labels: typeof c.labels === "object" && c.labels !== null ? c.labels : {},
+          discoveredAt: Date.now(),
+        })));
+
+        this.logger.info(
+          { nodeId, count: containers.length },
+          `Discovered ${containers.length} containers on node`
+        );
       }
     } catch (err) {
       this.logger.error(err, `Error handling agent message from ${nodeId}`);
@@ -3040,6 +3080,16 @@ export class WebSocketGateway {
     }
   }
 
+  // ── Discovered container accessors (for auto-import) ───────────────────
+
+  getDiscoveredContainers(nodeId: string) {
+    return this.discoveredContainers.get(nodeId) ?? [];
+  }
+
+  clearDiscoveredContainers(nodeId: string) {
+    this.discoveredContainers.delete(nodeId);
+  }
+
   /**
    * Destroy the gateway: close all connections and clean up resources.
    */
@@ -3069,6 +3119,7 @@ export class WebSocketGateway {
     this.globalSseSubscribers.clear();
     this.adminEventSubscribers.clear();
     this.pluginWsHandlers.clear();
+    this.discoveredContainers.clear();
     this.logger.info('WebSocket gateway destroyed');
   }
 }

--- a/catalyst-backend/src/websocket/gateway.ts
+++ b/catalyst-backend/src/websocket/gateway.ts
@@ -166,6 +166,9 @@ export class WebSocketGateway {
     image: string;
     status: string;
     labels: Record<string, string>;
+    networkMode?: string;
+    memoryLimitMb?: number;
+    cpuCores?: number;
     discoveredAt: number;
   }>>();
 
@@ -1816,6 +1819,9 @@ export class WebSocketGateway {
           image: String(c.image || ""),
           status: String(c.status || ""),
           labels: typeof c.labels === "object" && c.labels !== null ? c.labels : {},
+          networkMode: typeof c.networkMode === "string" ? c.networkMode : undefined,
+          memoryLimitMb: typeof c.memoryLimitMb === "number" ? c.memoryLimitMb : undefined,
+          cpuCores: typeof c.cpuCores === "number" ? c.cpuCores : undefined,
           discoveredAt: Date.now(),
         })));
 

--- a/catalyst-backend/src/websocket/gateway.ts
+++ b/catalyst-backend/src/websocket/gateway.ts
@@ -169,6 +169,8 @@ export class WebSocketGateway {
     networkMode?: string;
     memoryLimitMb?: number;
     cpuCores?: number;
+    startupCommand?: string;
+    envVarNames?: string[];
     discoveredAt: number;
   }>>();
 
@@ -1822,6 +1824,8 @@ export class WebSocketGateway {
           networkMode: typeof c.networkMode === "string" ? c.networkMode : undefined,
           memoryLimitMb: typeof c.memoryLimitMb === "number" ? c.memoryLimitMb : undefined,
           cpuCores: typeof c.cpuCores === "number" ? c.cpuCores : undefined,
+          startupCommand: typeof c.startupCommand === "string" ? c.startupCommand : undefined,
+          envVarNames: Array.isArray(c.envVarNames) ? c.envVarNames : undefined,
           discoveredAt: Date.now(),
         })));
 

--- a/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
+++ b/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
@@ -19,6 +19,8 @@ export interface UnregisteredContainer {
   networkMode?: string;
   memoryLimitMb?: number;
   cpuCores?: number;
+  startupCommand?: string;
+  envVarNames?: string[];
   discoveredAt: number;
 }
 
@@ -46,6 +48,14 @@ export default function ServerImportModal({
     allocatedDiskMb: string;
     primaryPort: string;
   }>>({});
+
+  // Template suggestions fetched from backend matching
+  const [suggestions, setSuggestions] = useState<Record<string, Array<{
+    templateId: string;
+    templateName: string;
+    score: number;
+    matchReasons: string[];
+  }>>>({});
 
   // Fetch templates for dropdown
   const { data: templates = [] } = useQuery({
@@ -109,6 +119,20 @@ export default function ServerImportModal({
   });
 
   if (!open) return null;
+
+  const fetchSuggestions = async (containerId: string) => {
+    try {
+      const results = await nodesApi.suggestTemplate(nodeId, containerId);
+      setSuggestions((prev) => ({ ...prev, [containerId]: results }));
+      // Auto-select top suggestion if no template selected yet
+      const form = getForm(containerId);
+      if (!form.templateId && results.length > 0) {
+        updateForm(containerId, { templateId: results[0].templateId });
+      }
+    } catch {
+      // Silently fail — suggestions are optional
+    }
+  };
 
   const getForm = (containerId: string) => {
     const container = containers.find((c) => c.containerId === containerId);
@@ -205,14 +229,36 @@ export default function ServerImportModal({
                                 </Badge>
                               )}
                             </div>
+                            {container.startupCommand && (
+                              <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground/70" title={container.startupCommand}>
+                                {container.startupCommand}
+                              </div>
+                            )}
+                            {container.envVarNames && container.envVarNames.length > 0 && (
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {container.envVarNames.slice(0, 8).map((name) => (
+                                  <span key={name} className="rounded bg-surface-2/50 px-1 py-0.5 text-[9px] text-muted-foreground">
+                                    {name}
+                                  </span>
+                                ))}
+                                {container.envVarNames.length > 8 && (
+                                  <span className="text-[9px] text-muted-foreground">+{container.envVarNames.length - 8} more</span>
+                                )}
+                              </div>
+                            )}
                           </div>
                         </div>
                         <Button
                           size="sm"
                           variant={isExpanded ? 'outline' : 'default'}
-                          onClick={() =>
-                            setImportingId(isExpanded ? null : container.containerId)
-                          }
+                          onClick={() => {
+                            if (isExpanded) {
+                              setImportingId(null);
+                            } else {
+                              setImportingId(container.containerId);
+                              fetchSuggestions(container.containerId);
+                            }
+                          }}
                           className="gap-1.5"
                         >
                           {isExpanded ? (
@@ -262,6 +308,26 @@ export default function ServerImportModal({
                                 }
                                 placeholder="Select template..."
                               />
+                              {suggestions[container.containerId] && suggestions[container.containerId].length > 0 && (
+                                <div className="mt-1 flex flex-wrap items-center gap-1">
+                                  <span className="text-[10px] text-muted-foreground">Suggested:</span>
+                                  {suggestions[container.containerId].slice(0, 3).map((s) => (
+                                    <button
+                                      key={s.templateId}
+                                      type="button"
+                                      onClick={() => updateForm(container.containerId, { templateId: s.templateId })}
+                                      className={`rounded px-1.5 py-0.5 text-[10px] transition-colors ${
+                                        form.templateId === s.templateId
+                                          ? 'bg-primary/20 text-primary font-medium'
+                                          : 'bg-surface-2/50 text-muted-foreground hover:bg-primary/10'
+                                      }`}
+                                      title={s.matchReasons.join('; ')}
+                                    >
+                                      {s.templateName} ({s.score})
+                                    </button>
+                                  ))}
+                                </div>
+                              )}
                             </div>
                             <div>
                               <label className="mb-1 block text-xs font-medium text-muted-foreground">

--- a/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
+++ b/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
@@ -1,0 +1,347 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Download, Loader2, Server, X } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { nodesApi } from '../../services/api/nodes';
+import { templatesApi } from '../../services/api/templates';
+import { adminApi } from '../../services/api/admin';
+import { notifyError, notifySuccess } from '../../utils/notify';
+import { ModalPortal } from '@/components/ui/modal-portal';
+import { motion } from 'framer-motion';
+import Combobox from '@/components/ui/combobox';
+
+export interface UnregisteredContainer {
+  containerId: string;
+  image: string;
+  status: string;
+  labels: Record<string, string>;
+  discoveredAt: number;
+}
+
+interface ServerImportModalProps {
+  open: boolean;
+  onClose: () => void;
+  nodeId: string;
+  containers: UnregisteredContainer[];
+}
+
+export default function ServerImportModal({
+  open,
+  onClose,
+  nodeId,
+  containers,
+}: ServerImportModalProps) {
+  const queryClient = useQueryClient();
+  const [importingId, setImportingId] = useState<string | null>(null);
+  const [formState, setFormState] = useState<Record<string, {
+    name: string;
+    templateId: string;
+    ownerId: string;
+    allocatedMemoryMb: string;
+    allocatedCpuCores: string;
+    allocatedDiskMb: string;
+    primaryPort: string;
+  }>>({});
+
+  // Fetch templates for dropdown
+  const { data: templates = [] } = useQuery({
+    queryKey: ['templates'],
+    queryFn: () => templatesApi.list(),
+    enabled: open,
+  });
+
+  // Fetch users for owner dropdown
+  const { data: usersData } = useQuery({
+    queryKey: ['admin-users'],
+    queryFn: () => adminApi.listUsers(),
+    enabled: open,
+  });
+  const users = usersData?.users ?? [];
+
+  const templateOptions = templates.map((t: any) => ({
+    value: t.id,
+    label: t.name,
+  }));
+
+  const userOptions = users.map((u: any) => ({
+    value: u.id,
+    label: u.email || u.name || u.id,
+  }));
+
+  const importMutation = useMutation({
+    mutationFn: async (containerId: string) => {
+      const form = formState[containerId];
+      if (!form?.name || !form?.templateId || !form?.ownerId) {
+        throw new Error('Name, template, and owner are required');
+      }
+      return nodesApi.importServer(nodeId, {
+        containerId,
+        name: form.name,
+        templateId: form.templateId,
+        ownerId: form.ownerId,
+        allocatedMemoryMb: form.allocatedMemoryMb ? Number(form.allocatedMemoryMb) : undefined,
+        allocatedCpuCores: form.allocatedCpuCores ? Number(form.allocatedCpuCores) : undefined,
+        allocatedDiskMb: form.allocatedDiskMb ? Number(form.allocatedDiskMb) : undefined,
+        primaryPort: form.primaryPort ? Number(form.primaryPort) : undefined,
+      });
+    },
+    onSuccess: () => {
+      notifySuccess('Server imported successfully');
+      queryClient.invalidateQueries({ queryKey: ['node', nodeId] });
+      queryClient.invalidateQueries({ queryKey: ['node-stats', nodeId] });
+      queryClient.invalidateQueries({ queryKey: ['unregistered-containers', nodeId] });
+      setImportingId(null);
+      setFormState((prev) => {
+        const next = { ...prev };
+        delete next[importingId!];
+        return next;
+      });
+    },
+    onError: (error: any) => {
+      const message = error?.response?.data?.error || error?.message || 'Failed to import server';
+      notifyError(message);
+      setImportingId(null);
+    },
+  });
+
+  if (!open) return null;
+
+  const getForm = (containerId: string) =>
+    formState[containerId] ?? {
+      name: '',
+      templateId: '',
+      ownerId: '',
+      allocatedMemoryMb: '',
+      allocatedCpuCores: '',
+      allocatedDiskMb: '10240',
+      primaryPort: '25565',
+    };
+
+  const updateForm = (containerId: string, updates: Record<string, string>) => {
+    setFormState((prev) => ({
+      ...prev,
+      [containerId]: { ...getForm(containerId), ...updates },
+    }));
+  };
+
+  return (
+    <ModalPortal>
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 px-4 backdrop-blur-sm">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.95 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+          className="w-full max-w-3xl rounded-xl border border-warning/30 bg-card shadow-xl"
+        >
+          <div className="flex items-center justify-between border-b border-warning/30 bg-warning/5 px-6 py-4">
+            <div className="flex items-center gap-2">
+              <Download className="h-5 w-5 text-warning" />
+              <h2 className="text-lg font-semibold text-foreground">
+                Import Discovered Servers
+              </h2>
+            </div>
+            <button
+              className="rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:border-primary/50 hover:text-foreground dark:text-foreground"
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
+
+          <div className="max-h-[70vh] overflow-y-auto px-6 py-4">
+            <div className="mb-4 text-sm text-muted-foreground">
+              {containers.length} container(s) found on this node that are not registered as servers.
+              Select a container and fill in the required details to import it.
+            </div>
+
+            {containers.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                No unregistered containers found.
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {containers.map((container) => {
+                  const isExpanded = importingId === container.containerId;
+                  const form = getForm(container.containerId);
+
+                  return (
+                    <div
+                      key={container.containerId}
+                      className="rounded-lg border border-border/50 bg-surface-2/30 p-4"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <Server className="h-4 w-4 text-muted-foreground" />
+                          <div>
+                            <div className="text-sm font-mono font-medium text-foreground">
+                              {container.containerId}
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                              <span>{container.image || 'Unknown image'}</span>
+                              <Badge
+                                variant={
+                                  container.status.includes('Up')
+                                    ? 'success'
+                                    : 'secondary'
+                                }
+                                className="text-[10px]"
+                              >
+                                {container.status.includes('Up') ? 'Running' : 'Stopped'}
+                              </Badge>
+                            </div>
+                          </div>
+                        </div>
+                        <Button
+                          size="sm"
+                          variant={isExpanded ? 'outline' : 'default'}
+                          onClick={() =>
+                            setImportingId(isExpanded ? null : container.containerId)
+                          }
+                          className="gap-1.5"
+                        >
+                          {isExpanded ? (
+                            <>
+                              <X className="h-3 w-3" />
+                              Cancel
+                            </>
+                          ) : (
+                            <>
+                              <Download className="h-3 w-3" />
+                              Import
+                            </>
+                          )}
+                        </Button>
+                      </div>
+
+                      {isExpanded && (
+                        <motion.div
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: 'auto' }}
+                          className="mt-4 space-y-3 border-t border-border/50 pt-4"
+                        >
+                          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Server Name *
+                              </label>
+                              <input
+                                type="text"
+                                value={form.name}
+                                onChange={(e) =>
+                                  updateForm(container.containerId, { name: e.target.value })
+                                }
+                                placeholder="My Server"
+                                className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none"
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Template *
+                              </label>
+                              <Combobox
+                                options={templateOptions}
+                                value={form.templateId}
+                                onChange={(val: string) =>
+                                  updateForm(container.containerId, { templateId: val })
+                                }
+                                placeholder="Select template..."
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Owner *
+                              </label>
+                              <Combobox
+                                options={userOptions}
+                                value={form.ownerId}
+                                onChange={(val: string) =>
+                                  updateForm(container.containerId, { ownerId: val })
+                                }
+                                placeholder="Select owner..."
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Primary Port
+                              </label>
+                              <input
+                                type="number"
+                                value={form.primaryPort}
+                                onChange={(e) =>
+                                  updateForm(container.containerId, { primaryPort: e.target.value })
+                                }
+                                className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                Memory (MB)
+                              </label>
+                              <input
+                                type="number"
+                                value={form.allocatedMemoryMb}
+                                onChange={(e) =>
+                                  updateForm(container.containerId, {
+                                    allocatedMemoryMb: e.target.value,
+                                  })
+                                }
+                                placeholder="1024"
+                                className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none"
+                              />
+                            </div>
+                            <div>
+                              <label className="mb-1 block text-xs font-medium text-muted-foreground">
+                                CPU Cores
+                              </label>
+                              <input
+                                type="number"
+                                value={form.allocatedCpuCores}
+                                onChange={(e) =>
+                                  updateForm(container.containerId, {
+                                    allocatedCpuCores: e.target.value,
+                                  })
+                                }
+                                placeholder="1"
+                                className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none"
+                              />
+                            </div>
+                          </div>
+
+                          <div className="flex justify-end gap-2 pt-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setImportingId(null)}
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              size="sm"
+                              onClick={() => importMutation.mutate(container.containerId)}
+                              disabled={
+                                !form.name || !form.templateId || !form.ownerId || importMutation.isPending
+                              }
+                              className="gap-1.5"
+                            >
+                              {importMutation.isPending ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                <Download className="h-3 w-3" />
+                              )}
+                              Import Server
+                            </Button>
+                          </div>
+                        </motion.div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </motion.div>
+      </div>
+    </ModalPortal>
+  );
+}

--- a/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
+++ b/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
@@ -202,9 +202,9 @@ export default function ServerImportModal({
                       className="rounded-lg border border-border/50 bg-surface-2/30 p-4"
                     >
                       <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-3">
-                          <Server className="h-4 w-4 text-muted-foreground" />
-                          <div>
+                        <div className="flex min-w-0 flex-1 items-center gap-3">
+                          <Server className="h-4 w-4 shrink-0 text-muted-foreground" />
+                          <div className="min-w-0 overflow-hidden">
                             <div className="text-sm font-mono font-medium text-foreground">
                               {container.containerId}
                             </div>
@@ -231,7 +231,7 @@ export default function ServerImportModal({
                             </div>
                             {container.startupCommand && (
                               <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground/70" title={container.startupCommand}>
-                                {container.startupCommand}
+                                {container.startupCommand.length > 120 ? container.startupCommand.slice(0, 120) + '…' : container.startupCommand}
                               </div>
                             )}
                             {container.envVarNames && container.envVarNames.length > 0 && (

--- a/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
+++ b/catalyst-frontend/src/components/nodes/ServerImportModal.tsx
@@ -16,6 +16,9 @@ export interface UnregisteredContainer {
   image: string;
   status: string;
   labels: Record<string, string>;
+  networkMode?: string;
+  memoryLimitMb?: number;
+  cpuCores?: number;
   discoveredAt: number;
 }
 
@@ -107,16 +110,20 @@ export default function ServerImportModal({
 
   if (!open) return null;
 
-  const getForm = (containerId: string) =>
-    formState[containerId] ?? {
-      name: '',
-      templateId: '',
-      ownerId: '',
-      allocatedMemoryMb: '',
-      allocatedCpuCores: '',
-      allocatedDiskMb: '10240',
-      primaryPort: '25565',
-    };
+  const getForm = (containerId: string) => {
+    const container = containers.find((c) => c.containerId === containerId);
+    return (
+      formState[containerId] ?? {
+        name: '',
+        templateId: '',
+        ownerId: '',
+        allocatedMemoryMb: container?.memoryLimitMb?.toString() ?? '',
+        allocatedCpuCores: container?.cpuCores?.toString() ?? '',
+        allocatedDiskMb: '10240',
+        primaryPort: '25565',
+      }
+    );
+  };
 
   const updateForm = (containerId: string, updates: Record<string, string>) => {
     setFormState((prev) => ({
@@ -189,6 +196,14 @@ export default function ServerImportModal({
                               >
                                 {container.status.includes('Up') ? 'Running' : 'Stopped'}
                               </Badge>
+                              {container.networkMode && (
+                                <Badge
+                                  variant={container.networkMode === 'host' ? 'warning' : 'outline'}
+                                  className="text-[10px]"
+                                >
+                                  {container.networkMode === 'host' ? 'Host Network' : 'Bridge'}
+                                </Badge>
+                              )}
                             </div>
                           </div>
                         </div>

--- a/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
+++ b/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
@@ -547,9 +547,9 @@ function NodeDetailsPage() {
               <div className="mt-3 divide-y divide-warning/10">
                 {unregisteredContainers.map((c: any) => (
                   <div key={c.containerId} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
-                    <div>
+                    <div className="min-w-0 flex-1 overflow-hidden">
                       <div className="font-mono text-xs font-medium text-foreground">{c.containerId}</div>
-                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                         <span>{c.image || 'Unknown image'}</span>
                         <Badge
                           variant={c.status?.includes('Up') ? 'success' : 'secondary'}
@@ -568,7 +568,7 @@ function NodeDetailsPage() {
                       </div>
                       {c.startupCommand && (
                         <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground/60" title={c.startupCommand}>
-                          {c.startupCommand}
+                          {c.startupCommand.length > 120 ? c.startupCommand.slice(0, 120) + '…' : c.startupCommand}
                         </div>
                       )}
                       {c.envVarNames && c.envVarNames.length > 0 && (

--- a/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
+++ b/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
@@ -17,6 +17,7 @@ import {
   AlertTriangle,
   Clock,
   Shield,
+  Download,
 } from 'lucide-react';
 import { Badge } from '../../components/ui/badge';
 import { Button } from '../../components/ui/button';
@@ -29,6 +30,7 @@ import NodeAssignmentModal from '../../components/nodes/NodeAssignmentModal';
 import { nodesApi } from '../../services/api/nodes';
 import { useAuthStore } from '../../stores/authStore';
 import { notifyError, notifySuccess } from '../../utils/notify';
+import ServerImportModal from '../../components/nodes/ServerImportModal';
 import { reportSystemError } from '../../services/api/systemErrors';
 import { ModalPortal } from '@/components/ui/modal-portal';
 
@@ -121,6 +123,7 @@ function NodeDetailsPage() {
   const [showAssignmentModal, setShowAssignmentModal] = useState(false);
   const [showUpdateModal, setShowUpdateModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showImportModal, setShowImportModal] = useState(false);
 
   // Check if API key exists for this node
   const { data: apiKeyStatus } = useQuery({
@@ -176,6 +179,14 @@ function NodeDetailsPage() {
     () => user?.permissions?.includes('admin.write') || user?.permissions?.includes('*'),
     [user?.permissions],
   );
+
+  const { data: unregisteredContainers = [] } = useQuery({
+    queryKey: ['unregistered-containers', nodeId],
+    queryFn: () => nodesApi.getUnregisteredContainers(nodeId!),
+    enabled: !!nodeId,
+    refetchInterval: 30000,
+  });
+
   const canAssignNodes = useMemo(
     () =>
       !!(
@@ -513,6 +524,48 @@ function NodeDetailsPage() {
           </div>
         </motion.div>
 
+        {/* ── Discovered Servers ── */}
+        {canWrite && unregisteredContainers.length > 0 && (
+          <motion.div variants={itemVariants}>
+            <div className="rounded-xl border border-warning/30 bg-warning/5 p-5 backdrop-blur-sm">
+              <div className="mb-4 flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <Download className="h-4 w-4 text-warning" />
+                  <h2 className="font-display text-sm font-semibold text-foreground">
+                    Discovered Servers
+                  </h2>
+                </div>
+                <Button size="sm" onClick={() => setShowImportModal(true)} className="gap-1.5">
+                  <Download className="h-3.5 w-3.5" />
+                  Import Servers
+                </Button>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {unregisteredContainers.length} container(s) found on this node that are not registered in the panel.
+                These may be servers from a previous panel installation.
+              </div>
+              <div className="mt-3 divide-y divide-warning/10">
+                {unregisteredContainers.map((c: any) => (
+                  <div key={c.containerId} className="flex items-center justify-between py-2 first:pt-0 last:pb-0">
+                    <div>
+                      <div className="font-mono text-xs font-medium text-foreground">{c.containerId}</div>
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <span>{c.image || 'Unknown image'}</span>
+                        <Badge
+                          variant={c.status?.includes('Up') ? 'success' : 'secondary'}
+                          className="text-[10px]"
+                        >
+                          {c.status?.includes('Up') ? 'Running' : 'Stopped'}
+                        </Badge>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+
         {/* ── Node Assignments ── */}
         {canWrite || canAssignNodes ? (
           <motion.div variants={itemVariants} className="space-y-4">
@@ -630,6 +683,14 @@ function NodeDetailsPage() {
         nodeId={nodeId!}
         open={showAssignmentModal}
         onClose={() => setShowAssignmentModal(false)}
+      />
+
+      {/* ── Server Import Modal ── */}
+      <ServerImportModal
+        open={showImportModal}
+        onClose={() => setShowImportModal(false)}
+        nodeId={nodeId!}
+        containers={unregisteredContainers}
       />
     </motion.div>
   );

--- a/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
+++ b/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
@@ -566,6 +566,23 @@ function NodeDetailsPage() {
                           </Badge>
                         )}
                       </div>
+                      {c.startupCommand && (
+                        <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground/60" title={c.startupCommand}>
+                          {c.startupCommand}
+                        </div>
+                      )}
+                      {c.envVarNames && c.envVarNames.length > 0 && (
+                        <div className="mt-1 flex flex-wrap gap-1">
+                          {c.envVarNames.slice(0, 6).map((name: string) => (
+                            <span key={name} className="rounded bg-warning/5 px-1 py-0.5 text-[9px] text-muted-foreground">
+                              {name}
+                            </span>
+                          ))}
+                          {c.envVarNames.length > 6 && (
+                            <span className="text-[9px] text-muted-foreground">+{c.envVarNames.length - 6} more</span>
+                          )}
+                        </div>
+                      )}
                     </div>
                   </div>
                 ))}

--- a/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
+++ b/catalyst-frontend/src/pages/nodes/NodeDetailsPage.tsx
@@ -557,6 +557,14 @@ function NodeDetailsPage() {
                         >
                           {c.status?.includes('Up') ? 'Running' : 'Stopped'}
                         </Badge>
+                        {c.networkMode && (
+                          <Badge
+                            variant={c.networkMode === 'host' ? 'warning' : 'outline'}
+                            className="text-[10px]"
+                          >
+                            {c.networkMode === 'host' ? 'Host Network' : 'Bridge'}
+                          </Badge>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/catalyst-frontend/src/services/api/nodes.ts
+++ b/catalyst-frontend/src/services/api/nodes.ts
@@ -230,10 +230,27 @@ export const nodesApi = {
           networkMode?: string;
           memoryLimitMb?: number;
           cpuCores?: number;
+          startupCommand?: string;
+          envVarNames?: string[];
           discoveredAt: number;
         }>
       >
     >(`/api/nodes/${nodeId}/unregistered-containers`);
+    return data.data || [];
+  },
+
+  // Suggest template match for an unregistered container
+  suggestTemplate: async (nodeId: string, containerId: string) => {
+    const data = await apiClient.get<
+      ApiResponse<
+        Array<{
+          templateId: string;
+          templateName: string;
+          score: number;
+          matchReasons: string[];
+        }>
+      >
+    >(`/api/nodes/${nodeId}/unregistered-containers/${containerId}/suggest-template`);
     return data.data || [];
   },
 

--- a/catalyst-frontend/src/services/api/nodes.ts
+++ b/catalyst-frontend/src/services/api/nodes.ts
@@ -227,6 +227,9 @@ export const nodesApi = {
           image: string;
           status: string;
           labels: Record<string, string>;
+          networkMode?: string;
+          memoryLimitMb?: number;
+          cpuCores?: number;
           discoveredAt: number;
         }>
       >

--- a/catalyst-frontend/src/services/api/nodes.ts
+++ b/catalyst-frontend/src/services/api/nodes.ts
@@ -217,4 +217,43 @@ export const nodesApi = {
     );
     return data;
   },
+
+  // Get unregistered containers on a node (containers not registered as servers)
+  getUnregisteredContainers: async (nodeId: string) => {
+    const data = await apiClient.get<
+      ApiResponse<
+        Array<{
+          containerId: string;
+          image: string;
+          status: string;
+          labels: Record<string, string>;
+          discoveredAt: number;
+        }>
+      >
+    >(`/api/nodes/${nodeId}/unregistered-containers`);
+    return data.data || [];
+  },
+
+  // Import a discovered container as a server
+  importServer: async (
+    nodeId: string,
+    payload: {
+      containerId: string;
+      name: string;
+      templateId: string;
+      ownerId: string;
+      allocatedMemoryMb?: number;
+      allocatedCpuCores?: number;
+      allocatedDiskMb?: number;
+      primaryPort?: number;
+      portBindings?: Record<number, number>;
+      environment?: Record<string, string>;
+    },
+  ) => {
+    const data = await apiClient.post<ApiResponse<any>>(
+      `/api/nodes/${nodeId}/import-server`,
+      payload,
+    );
+    return data.data;
+  },
 };


### PR DESCRIPTION
## Summary

Implements GitHub issue #111 — auto-import of existing Catalyst servers on a node when the agent is set up and linked with a panel. This is useful for disaster recovery scenarios (panel bricked, database dumped, etc.).

## How it works

1. **Agent discovers containers**: During state reconciliation, the agent sends a new `discovered_servers` WebSocket message listing all managed containers on the node.

2. **Backend tracks them**: The WebSocket gateway stores discovered containers in-memory, keyed by node ID. Unknown containers from `server_state_sync` are also tracked.

3. **OCI spec inspection**: The agent reads each container's OCI runtime spec to extract:
   - **Network mode** (bridge vs host) — critical for correct networking on import
   - **Memory/CPU limits** — for default resource allocation
   - **Startup command** (`process.args`) — strong signal for template identification
   - **Env var names** (`process.env` keys only, never values) — matches template variable definitions

4. **Template auto-suggestion**: The backend's new `GET /api/nodes/:nodeId/unregistered-containers/:containerId/suggest-template` endpoint scores all templates by:
   - Startup command structural token matching (up to 50 pts)
   - Environment variable name overlap (up to 30 pts)
   - Container image similarity (up to 20 pts)
   Returns top 5 ranked matches with match reasons.

5. **Admin views & imports**: The Node Details page shows a "Discovered Servers" section with startup command and env var badges. The import modal auto-selects the top template suggestion and displays clickable alternatives.

6. **Container ID reused**: The import sets `server.id = containerId`, ensuring the agent's existing state sync continues to work seamlessly.

## Changes

### Agent (Rust)
- Added `labels` field to `ContainerInfo` and populated from containerd
- Added `ContainerInspectInfo` with `network_mode`, `memory_limit_bytes`, `cpu_quota`, `cpu_period`, `startup_command`, `env_var_names`
- `inspect_container()` parses OCI spec to extract all identifying config
- Send `discovered_servers` WS message after state reconciliation with full container metadata

### Backend (TypeScript)
- **Gateway**: Added `discoveredContainers` map, handler for `discovered_servers`, public accessor methods, cleanup on disconnect
- **Gateway**: Unknown containers in `server_state_sync` tracked for import
- **Routes**: Added `GET /:nodeId/unregistered-containers` and `POST /:nodeId/import-server`
- **Routes**: Added `GET /:nodeId/unregistered-containers/:containerId/suggest-template` with multi-signal template scoring

### Frontend (React/TS)
- Added `getUnregisteredContainers`, `suggestTemplate`, and `importServer` API methods
- Added "Discovered Servers" section to Node Details page with startup/env info
- Created `ServerImportModal` with inline import form, template suggestions, and auto-selection

## Testing
- Agent: `cargo check`, `cargo clippy`, `cargo test` all pass
- Backend: `npx tsc --noEmit`, `bun run build`, lint all pass
- Frontend: `npx tsc --noEmit` passes (only pre-existing deprecation warning)

## Security notes
- Environment variable **values** are never transmitted — only names are extracted and sent
- The startup command from the OCI spec is the resolved command (env vars substituted), not secrets
- All admin-only endpoints require `admin.write` permission

Closes #111
