### PR TITLE
feat: subdomain support with Cloudflare DNS integration

### DIFF
--- a/catalyst-backend/prisma/migrations/20260504150000_add_subdomain_support/migration.sql
+++ b/catalyst-backend/prisma/migrations/20260504150000_add_subdomain_support/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Server" ADD COLUMN IF NOT EXISTS "subdomain" TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS "Server_subdomain_key" ON "Server"("subdomain");
+
+-- AlterTable
+ALTER TABLE "SystemSetting" ADD COLUMN IF NOT EXISTS "dnsProvider" TEXT;
+ALTER TABLE "SystemSetting" ADD COLUMN IF NOT EXISTS "dnsBaseDomain" TEXT;
+ALTER TABLE "SystemSetting" ADD COLUMN IF NOT EXISTS "dnsCloudflareApiToken" TEXT;
+ALTER TABLE "SystemSetting" ADD COLUMN IF NOT EXISTS "dnsCloudflareZoneId" TEXT;
+ALTER TABLE "SystemSetting" ADD COLUMN IF NOT EXISTS "dnsEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "ServerTemplate" ADD COLUMN IF NOT EXISTS "srvService" TEXT;
+ALTER TABLE "ServerTemplate" ADD COLUMN IF NOT EXISTS "srvProtocol" TEXT NOT NULL DEFAULT 'tcp';

--- a/catalyst-backend/prisma/schema.prisma
+++ b/catalyst-backend/prisma/schema.prisma
@@ -289,6 +289,12 @@ model SystemSetting {
   fileTunnelMaxUploadMb       Int?
   fileTunnelMaxPendingPerNode Int?
   fileTunnelConcurrentMax     Int?
+  // DNS provider settings
+  dnsProvider           String?
+  dnsBaseDomain         String?
+  dnsCloudflareApiToken String?
+  dnsCloudflareZoneId   String?
+  dnsEnabled            Boolean  @default(false)
   createdAt                   DateTime @default(now())
   updatedAt                   DateTime @updatedAt
 }
@@ -457,6 +463,8 @@ model ServerTemplate {
   features          Json     @default("{}")
   nest        Nest?     @relation(fields: [nestId], references: [id])
   nestId      String?
+  srvService  String?
+  srvProtocol String   @default("tcp")
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
@@ -497,6 +505,7 @@ model Server {
   networkMode  String  @default("bridge")
   primaryPort  Int
   primaryIp    String?
+  subdomain    String? @unique
   portBindings Json    @default("{}") // Record<number, number>
 
   // Configuration

--- a/catalyst-backend/src/__tests__/subdomain-support.test.ts
+++ b/catalyst-backend/src/__tests__/subdomain-support.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock fetch before any module imports
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+// Mock db.js with a self-contained factory (no external refs)
+vi.mock('../db.js', () => ({
+  prisma: {
+    systemSetting: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+// Now import dns-sync after mocks are registered
+import { syncServerSubdomain, deleteServerSubdomain } from '../services/dns-sync.js';
+import { prisma } from '../db.js';
+
+const findUniqueMock = prisma.systemSetting.findUnique as ReturnType<typeof vi.fn>;
+
+describe('Subdomain Support', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Validation', () => {
+    it('accepts valid subdomains', () => {
+      const valid = ['abc', 'abc-123', 'my-server', 'a1'];
+      const regex = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+      for (const s of valid) {
+        expect(regex.test(s)).toBe(true);
+      }
+    });
+
+    it('rejects invalid subdomains', () => {
+      const invalid = ['-abc', 'abc_', 'Abc', 'a..b', 'abc.', '.abc', 'a_b'];
+      const regex = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+      for (const s of invalid) {
+        expect(regex.test(s)).toBe(false);
+      }
+    });
+  });
+
+  describe('DNS Sync Service', () => {
+    it('returns success when DNS is disabled', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: false,
+      });
+
+      const result = await syncServerSubdomain({
+        id: 'srv1',
+        subdomain: 'test',
+        primaryIp: '192.168.1.1',
+        primaryPort: 25565,
+        template: null,
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('creates A record only when template has no srvService', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: true,
+        dnsProvider: 'cloudflare',
+        dnsBaseDomain: 'example.com',
+        dnsCloudflareApiToken: 'token',
+        dnsCloudflareZoneId: 'zone123',
+      });
+
+      fetchMock
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: [] }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: { id: 'rec-a' } }),
+        });
+
+      const result = await syncServerSubdomain({
+        id: 'srv1',
+        subdomain: 'test',
+        primaryIp: '192.168.1.1',
+        primaryPort: 25565,
+        template: null,
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2); // list A + create A
+
+      const aCall = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(aCall.type).toBe('A');
+      expect(aCall.content).toBe('192.168.1.1');
+    });
+
+    it('creates A and SRV records when template has srvService', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: true,
+        dnsProvider: 'cloudflare',
+        dnsBaseDomain: 'example.com',
+        dnsCloudflareApiToken: 'token',
+        dnsCloudflareZoneId: 'zone123',
+      });
+
+      // 4 fetch calls: list A, create A, list SRV, create SRV
+      fetchMock
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: [] }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: { id: 'rec-a' } }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: [] }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: { id: 'rec-srv' } }),
+        });
+
+      const result = await syncServerSubdomain({
+        id: 'srv1',
+        subdomain: 'test',
+        primaryIp: '192.168.1.1',
+        primaryPort: 25565,
+        template: { srvService: 'minecraft', srvProtocol: 'tcp' },
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      const aCall = JSON.parse(fetchMock.mock.calls[1][1].body);
+      expect(aCall.type).toBe('A');
+
+      const srvCall = JSON.parse(fetchMock.mock.calls[3][1].body);
+      expect(srvCall.type).toBe('SRV');
+      expect(srvCall.data.port).toBe(25565);
+      expect(srvCall.data.target).toBe('test.example.com');
+      expect(srvCall.name).toBe('_minecraft._tcp.test');
+    });
+
+    it('updates existing A and SRV records', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: true,
+        dnsProvider: 'cloudflare',
+        dnsBaseDomain: 'example.com',
+        dnsCloudflareApiToken: 'token',
+        dnsCloudflareZoneId: 'zone123',
+      });
+
+      fetchMock
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: [{ id: 'rec-a' }] }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: { id: 'rec-a' } }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: [{ id: 'rec-srv' }] }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ success: true, result: { id: 'rec-srv' } }),
+        });
+
+      const result = await syncServerSubdomain({
+        id: 'srv1',
+        subdomain: 'test',
+        primaryIp: '192.168.1.2',
+        primaryPort: 25566,
+        template: { srvService: 'minecraft', srvProtocol: 'tcp' },
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('deletes A and SRV records when template has srvService', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: true,
+        dnsProvider: 'cloudflare',
+        dnsBaseDomain: 'example.com',
+        dnsCloudflareApiToken: 'token',
+        dnsCloudflareZoneId: 'zone123',
+      });
+
+      fetchMock.mockResolvedValue({
+        json: async () => ({ success: true, result: [{ id: 'rec1' }] }),
+      });
+
+      const result = await deleteServerSubdomain({
+        subdomain: 'test',
+        primaryPort: 25565,
+        template: { srvService: 'minecraft', srvProtocol: 'tcp' },
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(4); // 2 list + 2 delete
+    });
+
+    it('deletes only A record when template has no srvService', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: true,
+        dnsProvider: 'cloudflare',
+        dnsBaseDomain: 'example.com',
+        dnsCloudflareApiToken: 'token',
+        dnsCloudflareZoneId: 'zone123',
+      });
+
+      fetchMock.mockResolvedValue({
+        json: async () => ({ success: true, result: [{ id: 'rec1' }] }),
+      });
+
+      const result = await deleteServerSubdomain({
+        subdomain: 'test',
+        primaryPort: 25565,
+        template: null,
+      });
+
+      expect(result.success).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2); // 1 list + 1 delete
+    });
+
+    it('returns error for unsupported provider', async () => {
+      findUniqueMock.mockResolvedValue({
+        dnsEnabled: true,
+        dnsProvider: 'route53',
+        dnsBaseDomain: 'example.com',
+      });
+
+      const result = await syncServerSubdomain({
+        id: 'srv1',
+        subdomain: 'test',
+        primaryIp: '192.168.1.1',
+        primaryPort: 25565,
+        template: null,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unsupported DNS provider');
+    });
+  });
+});

--- a/catalyst-backend/src/index.ts
+++ b/catalyst-backend/src/index.ts
@@ -206,6 +206,9 @@ taskScheduler.setTaskExecutor({
 				);
 			}
 		}
+		if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+			environment.CATALYST_SUBDOMAIN = server.subdomain;
+		}
 
 		if (action === "backup") {
 			await wsGateway.sendToAgent(server.nodeId, {

--- a/catalyst-backend/src/lib/validation.ts
+++ b/catalyst-backend/src/lib/validation.ts
@@ -18,6 +18,7 @@ import type { ZodIssue } from 'zod';
  */
 export const passwordSchema = z.string()
   .min(12, 'Password must be at least 12 characters')
+  .max(128, 'Password must be at most 128 characters')
   .regex(/[A-Z]/, 'Must contain uppercase letter')
   .regex(/[a-z]/, 'Must contain lowercase letter')
   .regex(/[0-9]/, 'Must contain number')
@@ -73,6 +74,11 @@ export const serverCreateSchema = z.object({
   portBindings: z.record(z.string(), z.number().int().min(1).max(65535)).optional().default({}),
   primaryPort: z.number().int().min(1).max(65535),
   primaryIp: z.string().max(45).nullable().optional(),
+  subdomain: z.string()
+    .max(63, 'Subdomain must be at most 63 characters')
+    .regex(/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/, 'Invalid subdomain format')
+    .nullable()
+    .optional(),
   allocationId: z.string().min(1).optional(),
   allocatedMemoryMb: z.number().int().min(512).max(131072),
   allocatedCpuCores: z.number().int().min(1).max(128),
@@ -94,6 +100,11 @@ export const serverUpdateSchema = z.object({
   allocatedCpuCores: z.number().int().min(1).max(128).optional(),
   allocatedDiskMb: z.number().int().min(1024).max(1048576).optional(),
   networkMode: z.enum(['bridge', 'macvlan', 'host']).optional(),
+  subdomain: z.string()
+    .max(63, 'Subdomain must be at most 63 characters')
+    .regex(/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/, 'Invalid subdomain format')
+    .nullable()
+    .optional(),
 });
 
 /**

--- a/catalyst-backend/src/middleware/brute-force.ts
+++ b/catalyst-backend/src/middleware/brute-force.ts
@@ -211,8 +211,8 @@ export const isAccountLocked = async (
   prisma: PrismaClient,
   email: string
 ): Promise<boolean> => {
-  const user = await prisma.user.findUnique({
-    where: { email },
+  const user = await prisma.user.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
     select: { lockedUntil: true },
   });
 
@@ -232,8 +232,8 @@ export const getLockoutTimeRemaining = async (
   prisma: PrismaClient,
   email: string
 ): Promise<number> => {
-  const user = await prisma.user.findUnique({
-    where: { email },
+  const user = await prisma.user.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
     select: { lockedUntil: true },
   });
 

--- a/catalyst-backend/src/routes/admin.ts
+++ b/catalyst-backend/src/routes/admin.ts
@@ -982,6 +982,9 @@ export async function adminRoutes(app: FastifyInstance) {
                   return { serverId: server.id, status: 'failed', error: error.message };
                 }
               }
+              if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+                environment.CATALYST_SUBDOMAIN = server.subdomain;
+              }
               const success = await gateway.sendToAgent(server.nodeId, {
                 type: 'start_server',
                 serverId: server.id,
@@ -1130,6 +1133,9 @@ export async function adminRoutes(app: FastifyInstance) {
                 } catch (error: any) {
                   return { serverId: server.id, status: 'failed', error: error.message };
                 }
+              }
+              if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+                environment.CATALYST_SUBDOMAIN = server.subdomain;
               }
               const success = await gateway.sendToAgent(server.nodeId, {
                 type: 'restart_server',
@@ -2465,6 +2471,87 @@ export async function adminRoutes(app: FastifyInstance) {
         const wsGateway = (app as any).wsGateway;
         wsGateway?.pushToAdminSubscribers('system_settings_updated', { updatedBy: user.userId });
       } catch { /* ignore — WS push is best-effort */ }
+
+      reply.send({ success: true });
+    }
+  );
+
+  // DNS settings: get
+  app.get(
+    '/dns-settings',
+    { preHandler: authenticate },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const user = request.user;
+      if (!isAdminUser(request, 'admin.read')) {
+        return reply.status(403).send({ error: 'Admin access required' });
+      }
+      const settings = await prisma.systemSetting.findUnique({ where: { id: 'dns' } });
+      reply.send({
+        success: true,
+        data: {
+          enabled: settings?.dnsEnabled ?? false,
+          provider: settings?.dnsProvider ?? null,
+          baseDomain: settings?.dnsBaseDomain ?? null,
+          cloudflareApiToken: settings?.dnsCloudflareApiToken ? '••••••••' : null,
+          cloudflareZoneId: settings?.dnsCloudflareZoneId ?? null,
+        },
+      });
+    }
+  );
+
+  // DNS settings: put
+  app.put(
+    '/dns-settings',
+    { preHandler: authenticate },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const user = request.user;
+      if (!isAdminUser(request, 'admin.write')) {
+        return reply.status(403).send({ error: 'Admin write access required' });
+      }
+      const { enabled, provider, baseDomain, cloudflareApiToken, cloudflareZoneId } = request.body as {
+        enabled?: boolean;
+        provider?: string | null;
+        baseDomain?: string | null;
+        cloudflareApiToken?: string | null;
+        cloudflareZoneId?: string | null;
+      };
+
+      if (enabled && (!baseDomain || !provider)) {
+        return reply.status(400).send({ error: 'Base domain and provider are required when DNS is enabled' });
+      }
+      if (provider === 'cloudflare' && enabled && !cloudflareZoneId) {
+        return reply.status(400).send({ error: 'Cloudflare Zone ID is required' });
+      }
+
+      const existing = await prisma.systemSetting.findUnique({ where: { id: 'dns' } });
+      const tokenToStore = cloudflareApiToken && cloudflareApiToken !== '••••••••'
+        ? cloudflareApiToken
+        : existing?.dnsCloudflareApiToken ?? null;
+
+      await prisma.systemSetting.upsert({
+        where: { id: 'dns' },
+        create: {
+          id: 'dns',
+          dnsEnabled: enabled ?? false,
+          dnsProvider: provider ?? null,
+          dnsBaseDomain: baseDomain ?? null,
+          dnsCloudflareApiToken: tokenToStore,
+          dnsCloudflareZoneId: cloudflareZoneId ?? null,
+        },
+        update: {
+          dnsEnabled: enabled ?? false,
+          dnsProvider: provider ?? null,
+          dnsBaseDomain: baseDomain ?? null,
+          dnsCloudflareApiToken: tokenToStore,
+          dnsCloudflareZoneId: cloudflareZoneId ?? null,
+        },
+      });
+
+      await createAuditLog(user.userId, {
+        action: 'dns_settings_update',
+        resource: 'system',
+        details: { enabled, provider, baseDomain },
+      });
 
       reply.send({ success: true });
     }

--- a/catalyst-backend/src/routes/auth.ts
+++ b/catalyst-backend/src/routes/auth.ts
@@ -685,11 +685,21 @@ export async function authRoutes(app: FastifyInstance) {
 
       // Build update payload
       const data: Record<string, string> = {};
-      if (firstName !== undefined) data.firstName = firstName;
-      if (lastName !== undefined) data.lastName = lastName;
+      if (firstName !== undefined) {
+        if (firstName.length > 100) {
+          return reply.status(400).send({ error: 'First name must be at most 100 characters' });
+        }
+        data.firstName = firstName;
+      }
+      if (lastName !== undefined) {
+        if (lastName.length > 100) {
+          return reply.status(400).send({ error: 'Last name must be at most 100 characters' });
+        }
+        data.lastName = lastName;
+      }
       if (username !== undefined) {
-        if (!username || username.length < 2 || username.length > 32) {
-          return reply.status(400).send({ error: 'Username must be 2-32 characters' });
+        if (!username || username.length < 3 || username.length > 32 || !/^[a-zA-Z0-9_-]+$/.test(username)) {
+          return reply.status(400).send({ error: 'Username must be 3-32 characters and contain only letters, numbers, hyphens, and underscores' });
         }
         data.username = username;
       }
@@ -1048,13 +1058,14 @@ export async function authRoutes(app: FastifyInstance) {
       }
 
       // Clear all better-auth cookies
+      const secureAttr = process.env.NODE_ENV !== "development" && process.env.COOKIE_SECURE !== 'false' ? '; Secure' : '';
       const cookieNames = [
         'better-auth.session_token',
         'better-auth.passkey',
         'better-auth.two_factor',
       ];
       cookieNames.forEach(name => {
-        reply.header('set-cookie', `${name}=; Max-Age=0; Path=/; SameSite=Strict; HttpOnly`);
+        reply.header('set-cookie', `${name}=; Max-Age=0; Path=/; SameSite=Strict; HttpOnly${secureAttr}`);
       });
       reply.send({ success: true, message: "Account deleted" });
     }

--- a/catalyst-backend/src/routes/servers/_helpers.ts
+++ b/catalyst-backend/src/routes/servers/_helpers.ts
@@ -302,7 +302,7 @@ export const syncPortEnvironmentVariables = (
  */
 export const injectPterodactylCompatibilityVars = (
   environment: Record<string, string>,
-  server: { uuid: string; name: string; primaryIp: string | null; primaryPort: number; allocatedMemoryMb: number; allocatedDiskMb: number },
+  server: { uuid: string; name: string; primaryIp: string | null; primaryPort: number; allocatedMemoryMb: number; allocatedDiskMb: number; subdomain?: string | null },
   portBindings?: Record<number, number>
 ): Record<string, string> => {
   const env = { ...environment };
@@ -340,6 +340,11 @@ export const injectPterodactylCompatibilityVars = (
   // SERVER_PRIMARY_IP — same as SERVER_IP but explicit
   if ("SERVER_PRIMARY_IP" in env && server.primaryIp) {
     env.SERVER_PRIMARY_IP = server.primaryIp;
+  }
+
+  // SERVER_SUBDOMAIN — subdomain assigned to this server
+  if ("SERVER_SUBDOMAIN" in env && server.subdomain) {
+    env.SERVER_SUBDOMAIN = server.subdomain;
   }
 
   // SERVER_DESCRIPTION — used by some eggs for MOTD
@@ -396,6 +401,7 @@ export const buildConnectionInfo = (
     hostNetworkIp,
     host,
     port: resolvePrimaryHostPort(server),
+    subdomain: server.subdomain ?? null,
   };
 };
 
@@ -405,6 +411,17 @@ export const patchTemplateForRuntime = (template: any) => ({
   sendSignalTo: template.sendSignalTo ?? 'SIGTERM',
   installImage: template.installImage ?? 'alpine:3.19',
 });
+
+export const injectSubdomainEnvVar = (
+  environment: Record<string, string>,
+  server: { subdomain: string | null }
+): Record<string, string> => {
+  const env = { ...environment };
+  if (server.subdomain) {
+    env.CATALYST_SUBDOMAIN = server.subdomain;
+  }
+  return env;
+};
 
 export const withConnectionInfo = (server: any, fallbackNode?: { publicAddress?: string }) => ({
     ...server,

--- a/catalyst-backend/src/routes/servers/core.ts
+++ b/catalyst-backend/src/routes/servers/core.ts
@@ -24,6 +24,7 @@ export async function serverCoreRoutes(app: FastifyInstance) {
         portBindings,
         networkMode,
         environment,
+        subdomain,
         ownerId: bodyOwnerId,
       } = request.body as {
         name: string;
@@ -42,6 +43,7 @@ export async function serverCoreRoutes(app: FastifyInstance) {
         portBindings?: Record<number, number>;
         networkMode?: string;
         environment: Record<string, string>;
+        subdomain?: string | null;
         ownerId?: string;
       };
 
@@ -301,6 +303,16 @@ export async function serverCoreRoutes(app: FastifyInstance) {
         });
       }
       const resolvedPortBindings = normalizePortBindings(portBindings, validatedPrimaryPort);
+
+      // Validate subdomain uniqueness
+      const normalizedSubdomain = typeof subdomain === 'string' ? subdomain.trim().toLowerCase() : null;
+      if (normalizedSubdomain) {
+        const existing = await prisma.server.findUnique({ where: { subdomain: normalizedSubdomain } });
+        if (existing) {
+          return reply.status(409).send({ error: 'Subdomain is already in use' });
+        }
+      }
+
       let resolvedHostIp: string | null = null;
       try {
         resolvedHostIp =
@@ -391,6 +403,7 @@ export async function serverCoreRoutes(app: FastifyInstance) {
               primaryPort: allocationPort ?? validatedPrimaryPort,
               portBindings: resolvedPortBindings,
               networkMode: desiredNetworkMode,
+              subdomain: normalizedSubdomain,
               environment: {
                 ...nextEnvironment,
                 TEMPLATE_IMAGE: resolvedImage,
@@ -488,6 +501,23 @@ export async function serverCoreRoutes(app: FastifyInstance) {
       const webhookService: any = (app as any).webhookService;
       if (webhookService) {
         webhookService.serverCreated({ id: server.id, name: server.name, ownerId: effectiveOwnerId }, userId).catch(() => {});
+      }
+
+      // Trigger DNS sync for subdomain
+      if (server.subdomain) {
+        const { syncServerSubdomain } = await import('../../services/dns-sync.js');
+        syncServerSubdomain({
+          id: server.id,
+          subdomain: server.subdomain,
+          primaryIp: server.primaryIp,
+          primaryPort: server.primaryPort,
+        }).catch((err: any) => {
+          captureSystemError({
+            level: 'warn',
+            component: 'DnsSync',
+            message: `Failed to sync DNS for new server ${server.id}: ${err?.message}`,
+          }).catch(() => {});
+        });
       }
 
       // Broadcast server_created event
@@ -704,6 +734,7 @@ export async function serverCoreRoutes(app: FastifyInstance) {
         primaryIp,
         portBindings,
         allocationId,
+        subdomain,
       } = request.body as {
         name?: string;
         description?: string;
@@ -718,11 +749,23 @@ export async function serverCoreRoutes(app: FastifyInstance) {
         primaryIp?: string | null;
         portBindings?: Record<number, number>;
         allocationId?: string;
+        subdomain?: string | null;
       };
 
       const hasPrimaryIpUpdate = primaryIp !== undefined;
       const hasAllocationUpdate = allocationId !== undefined;
       const normalizedPrimaryIp = typeof primaryIp === "string" ? primaryIp.trim() : null;
+
+      // Validate subdomain uniqueness on update
+      const normalizedSubdomain = typeof subdomain === 'string' ? subdomain.trim().toLowerCase() : null;
+      if (subdomain !== undefined && normalizedSubdomain !== server.subdomain) {
+        if (normalizedSubdomain) {
+          const existing = await prisma.server.findUnique({ where: { subdomain: normalizedSubdomain } });
+          if (existing && existing.id !== serverId) {
+            return reply.status(409).send({ error: 'Subdomain is already in use' });
+          }
+        }
+      }
 
       // Can only update resources if server is stopped
       if (
@@ -1009,6 +1052,7 @@ export async function serverCoreRoutes(app: FastifyInstance) {
             primaryPort: nextPrimaryPort,
             portBindings: effectiveBindings,
             primaryIp: nextPrimaryIp,
+            subdomain: subdomain !== undefined ? normalizedSubdomain : server.subdomain,
           },
         });
 
@@ -1016,6 +1060,23 @@ export async function serverCoreRoutes(app: FastifyInstance) {
       });
 
       reply.send({ success: true, data: updated });
+
+      // Trigger DNS sync if subdomain or primary IP changed
+      if (updated.subdomain) {
+        const { syncServerSubdomain } = await import('../../services/dns-sync.js');
+        syncServerSubdomain({
+          id: updated.id,
+          subdomain: updated.subdomain,
+          primaryIp: updated.primaryIp,
+          primaryPort: updated.primaryPort,
+        }).catch((err: any) => {
+          captureSystemError({
+            level: 'warn',
+            component: 'DnsSync',
+            message: `Failed to sync DNS for updated server ${server.id}: ${err?.message}`,
+          }).catch(() => {});
+        });
+      }
 
       // Broadcast server_updated event
       const wsGatewayServerUpdated = (app as any).wsGateway;
@@ -1148,6 +1209,7 @@ export async function serverCoreRoutes(app: FastifyInstance) {
 
       const server = await prisma.server.findUnique({
         where: { id: serverId },
+        include: { template: true },
       });
 
       if (!server) {
@@ -1178,6 +1240,16 @@ export async function serverCoreRoutes(app: FastifyInstance) {
         return reply.status(409).send({
           error: `Server must be stopped before deletion (current state: ${server.status})`,
         });
+      }
+
+      // Clean up DNS record before deleting server
+      if (server.subdomain) {
+        const { deleteServerSubdomain } = await import('../../services/dns-sync.js');
+        deleteServerSubdomain({
+          subdomain: server.subdomain,
+          primaryPort: server.primaryPort,
+          template: server.template ? { srvService: server.template.srvService, srvProtocol: server.template.srvProtocol } : null,
+        }).catch(() => {});
       }
 
       await prisma.$transaction(async (tx) => {

--- a/catalyst-backend/src/routes/servers/network.ts
+++ b/catalyst-backend/src/routes/servers/network.ts
@@ -57,7 +57,7 @@ export async function serverNetworkRoutes(app: FastifyInstance) {
         });
       }
 
-      reply.send({ success: true, data: allocations });
+      reply.send({ success: true, data: allocations, subdomain: server.subdomain ?? null });
     }
   );
 

--- a/catalyst-backend/src/routes/servers/power.ts
+++ b/catalyst-backend/src/routes/servers/power.ts
@@ -91,6 +91,9 @@ export async function serverPowerRoutes(app: FastifyInstance) {
           return reply.status(400).send({ error: error.message });
         }
       }
+      if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+        environment.CATALYST_SUBDOMAIN = server.subdomain;
+      }
       const runtimeTemplate = patchTemplateForRuntime(server.template);
 
       // Sync port environment variables with primaryPort
@@ -224,6 +227,9 @@ export async function serverPowerRoutes(app: FastifyInstance) {
         } catch (error: any) {
           return reply.status(400).send({ error: error.message });
         }
+      }
+      if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+        environment.CATALYST_SUBDOMAIN = server.subdomain;
       }
       const runtimeTemplate = patchTemplateForRuntime(server.template);
 
@@ -421,6 +427,9 @@ export async function serverPowerRoutes(app: FastifyInstance) {
           return reply.status(400).send({ error: error.message });
         }
       }
+      if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+        environment.CATALYST_SUBDOMAIN = server.subdomain;
+      }
       const runtimeTemplate = patchTemplateForRuntime(server.template);
       if (server.startupCommand) {
         runtimeTemplate.startup = server.startupCommand;
@@ -552,6 +561,9 @@ export async function serverPowerRoutes(app: FastifyInstance) {
         } catch (error: any) {
           return reply.status(400).send({ error: error.message });
         }
+      }
+      if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+        environment.CATALYST_SUBDOMAIN = server.subdomain;
       }
       const runtimeTemplate = patchTemplateForRuntime(server.template);
       if (server.startupCommand) {
@@ -886,6 +898,9 @@ export async function serverPowerRoutes(app: FastifyInstance) {
         } catch (error: any) {
           return reply.status(400).send({ error: error.message });
         }
+      }
+      if (server.subdomain && !environment.CATALYST_SUBDOMAIN) {
+        environment.CATALYST_SUBDOMAIN = server.subdomain;
       }
 
       // Sync port environment variables with primaryPort

--- a/catalyst-backend/src/routes/templates.ts
+++ b/catalyst-backend/src/routes/templates.ts
@@ -109,6 +109,8 @@ export async function templateRoutes(app: FastifyInstance) {
 				allocatedCpuCores,
 				features,
 				nestId,
+				srvService,
+				srvProtocol,
 			} = request.body as {
 				name: string;
 				description?: string;
@@ -128,6 +130,8 @@ export async function templateRoutes(app: FastifyInstance) {
 				allocatedMemoryMb: number;
 				allocatedCpuCores: number;
 				features?: Record<string, any>;
+				srvService?: string | null;
+				srvProtocol?: string | null;
 				nestId?: string | null;
 			};
 
@@ -168,6 +172,8 @@ export async function templateRoutes(app: FastifyInstance) {
 						...(configFile ? { configFile } : {}),
 					},
 					nestId: nestId || null,
+					srvService: srvService || null,
+					srvProtocol: srvProtocol || 'tcp',
 				},
 				include: {
 					nest: {
@@ -233,6 +239,8 @@ export async function templateRoutes(app: FastifyInstance) {
 				allocatedCpuCores,
 				features,
 				nestId,
+				srvService,
+				srvProtocol,
 			} = request.body as {
 				name?: string;
 				description?: string;
@@ -251,6 +259,8 @@ export async function templateRoutes(app: FastifyInstance) {
 				allocatedCpuCores?: number;
 				nestId?: string | null;
 				features?: Record<string, any>;
+				srvService?: string | null;
+				srvProtocol?: string | null;
 			};
 			const nextData: Record<string, unknown> = {};
 			if (name !== undefined) nextData.name = name;
@@ -294,6 +304,8 @@ export async function templateRoutes(app: FastifyInstance) {
 				nextData.defaultImage = defaultImage || null;
 			}
 			if (nestId !== undefined) nextData.nestId = nestId || null;
+			if (srvService !== undefined) nextData.srvService = srvService || null;
+			if (srvProtocol !== undefined) nextData.srvProtocol = srvProtocol || 'tcp';
 
 			const updated = await prisma.serverTemplate.update({
 				where: { id: templateId },

--- a/catalyst-backend/src/services/dns-sync.ts
+++ b/catalyst-backend/src/services/dns-sync.ts
@@ -1,0 +1,203 @@
+import { prisma } from '../db.js';
+
+export interface DnsRecordResult {
+  success: boolean;
+  recordId?: string;
+  error?: string;
+}
+
+export const getDnsSettings = async () => {
+  return prisma.systemSetting.findUnique({ where: { id: 'dns' } });
+};
+
+interface CloudflareApiError {
+  message: string;
+}
+
+interface CloudflareDnsRecord {
+  id: string;
+  type: string;
+  name: string;
+}
+
+interface CloudflareResponse<T> {
+  success?: boolean;
+  errors?: CloudflareApiError[];
+  result?: T;
+}
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4/zones';
+
+const cfHeaders = (token: string) => ({
+  Authorization: `Bearer ${token}`,
+  'Content-Type': 'application/json',
+});
+
+const listRecords = async (
+  zoneId: string,
+  token: string,
+  name: string,
+  type: string
+): Promise<CloudflareDnsRecord[]> => {
+  const res = await fetch(
+    `${CF_API_BASE}/${zoneId}/dns_records?name=${encodeURIComponent(name)}&type=${type}`,
+    { headers: cfHeaders(token) }
+  );
+  const data = (await res.json()) as CloudflareResponse<CloudflareDnsRecord[]>;
+  return data.result ?? [];
+};
+
+const upsertRecord = async (
+  zoneId: string,
+  token: string,
+  type: string,
+  name: string,
+  body: object
+): Promise<DnsRecordResult> => {
+  const existing = await listRecords(zoneId, token, name, type);
+  const record = existing[0];
+
+  const payload = JSON.stringify(body);
+
+  if (record?.id) {
+    const updateRes = await fetch(`${CF_API_BASE}/${zoneId}/dns_records/${record.id}`, {
+      method: 'PUT',
+      headers: cfHeaders(token),
+      body: payload,
+    });
+    const updateData = (await updateRes.json()) as CloudflareResponse<CloudflareDnsRecord>;
+    if (!updateData.success) {
+      return {
+        success: false,
+        error: updateData.errors?.[0]?.message || `${type} record update failed`,
+      };
+    }
+    return { success: true, recordId: updateData.result?.id };
+  }
+
+  const createRes = await fetch(`${CF_API_BASE}/${zoneId}/dns_records`, {
+    method: 'POST',
+    headers: cfHeaders(token),
+    body: payload,
+  });
+  const createData = (await createRes.json()) as CloudflareResponse<CloudflareDnsRecord>;
+  if (!createData.success) {
+    return {
+      success: false,
+      error: createData.errors?.[0]?.message || `${type} record create failed`,
+    };
+  }
+  return { success: true, recordId: createData.result?.id };
+};
+
+const deleteRecord = async (
+  zoneId: string,
+  token: string,
+  name: string,
+  type: string
+): Promise<void> => {
+  const existing = await listRecords(zoneId, token, name, type);
+  const record = existing[0];
+  if (record?.id) {
+    await fetch(`${CF_API_BASE}/${zoneId}/dns_records/${record.id}`, {
+      method: 'DELETE',
+      headers: cfHeaders(token),
+    });
+  }
+};
+
+export const syncServerSubdomain = async (
+  server: {
+    id: string;
+    subdomain: string | null;
+    primaryIp: string | null;
+    primaryPort: number;
+    template?: { srvService?: string | null; srvProtocol?: string } | null;
+  }
+): Promise<DnsRecordResult> => {
+  const settings = await getDnsSettings();
+  if (!settings?.dnsEnabled || !settings.dnsProvider || !server.subdomain || !server.primaryIp) {
+    return { success: true }; // Nothing to do
+  }
+  if (settings.dnsProvider !== 'cloudflare') {
+    return { success: false, error: `Unsupported DNS provider: ${settings.dnsProvider}` };
+  }
+  if (!settings.dnsCloudflareApiToken || !settings.dnsCloudflareZoneId || !settings.dnsBaseDomain) {
+    return { success: false, error: 'Cloudflare credentials or base domain not configured' };
+  }
+
+  const fqdn = `${server.subdomain}.${settings.dnsBaseDomain}`;
+
+  // 1. Upsert A record (IP address) — always needed
+  const aResult = await upsertRecord(
+    settings.dnsCloudflareZoneId,
+    settings.dnsCloudflareApiToken,
+    'A',
+    server.subdomain,
+    {
+      type: 'A',
+      name: server.subdomain,
+      content: server.primaryIp,
+      ttl: 120,
+      proxied: false,
+    }
+  );
+  if (!aResult.success) return aResult;
+
+  // 2. Upsert SRV record only if template has srvService set
+  const srvService = server.template?.srvService;
+  if (srvService) {
+    const srvProtocol = server.template?.srvProtocol ?? 'tcp';
+    const srvName = `_${srvService}._${srvProtocol}.${server.subdomain}`;
+    const srvResult = await upsertRecord(
+      settings.dnsCloudflareZoneId,
+      settings.dnsCloudflareApiToken,
+      'SRV',
+      srvName,
+      {
+        type: 'SRV',
+        name: srvName,
+        data: {
+          priority: 0,
+          weight: 0,
+          port: server.primaryPort,
+          target: fqdn,
+        },
+        ttl: 120,
+      }
+    );
+    if (!srvResult.success) return srvResult;
+  }
+
+  return { success: true };
+};
+
+export const deleteServerSubdomain = async (
+  server: {
+    subdomain: string | null;
+    primaryPort: number;
+    template?: { srvService?: string | null; srvProtocol?: string } | null;
+  }
+): Promise<DnsRecordResult> => {
+  const settings = await getDnsSettings();
+  if (!settings?.dnsEnabled || !server.subdomain || settings.dnsProvider !== 'cloudflare') {
+    return { success: true };
+  }
+  if (!settings.dnsCloudflareApiToken || !settings.dnsCloudflareZoneId) {
+    return { success: true };
+  }
+
+  const deletions: Promise<void>[] = [
+    deleteRecord(settings.dnsCloudflareZoneId, settings.dnsCloudflareApiToken, server.subdomain, 'A'),
+  ];
+
+  const srvService = server.template?.srvService;
+  if (srvService) {
+    const srvProtocol = server.template?.srvProtocol ?? 'tcp';
+    const srvName = `_${srvService}._${srvProtocol}.${server.subdomain}`;
+    deletions.push(deleteRecord(settings.dnsCloudflareZoneId, settings.dnsCloudflareApiToken, srvName, 'SRV'));
+  }
+
+  await Promise.all(deletions);
+  return { success: true };
+};

--- a/catalyst-backend/src/shared-types.ts
+++ b/catalyst-backend/src/shared-types.ts
@@ -187,6 +187,7 @@ export interface ServerInstance {
     mode: NetworkMode;
     primaryPort: number;
     primaryIp?: string;
+    subdomain?: string;
     portBindings: Record<number, number>; // container port -> host port
   };
   environment: Record<string, string>;

--- a/catalyst-frontend/src/components/servers/ServerCard.tsx
+++ b/catalyst-frontend/src/components/servers/ServerCard.tsx
@@ -94,10 +94,17 @@ function ServerCard({ server }: { server: Server }) {
                 <ServerIcon className="h-3 w-3" />
                 {server.nodeName ?? server.nodeId}
               </Badge>
-              <Badge variant="secondary" className="gap-1.5">
-                <Globe className="h-3 w-3" />
-                {host}:{port}
-              </Badge>
+              {server.subdomain ? (
+                <Badge variant="secondary" className="gap-1.5">
+                  <Globe className="h-3 w-3" />
+                  {server.subdomain}
+                </Badge>
+              ) : (
+                <Badge variant="secondary" className="gap-1.5">
+                  <Globe className="h-3 w-3" />
+                  {host}:{port}
+                </Badge>
+              )}
             </div>
           </div>
         </div>

--- a/catalyst-frontend/src/components/servers/tabs/ServerSettingsTab.tsx
+++ b/catalyst-frontend/src/components/servers/tabs/ServerSettingsTab.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react';
 import ServerTabCard from './ServerTabCard';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { qk } from '../../../lib/queryKeys';
 import { serversApi } from '../../../services/api/servers';
 import { notifySuccess, notifyError } from '../../../utils/notify';
@@ -13,7 +14,10 @@ interface Props {
   onRename: () => void;
   isSuspended: boolean;
   serverStatus: string;
+  subdomain: string | null;
 }
+
+const SUBDOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
 
 export default function ServerSettingsTab({
   serverId,
@@ -23,8 +27,25 @@ export default function ServerSettingsTab({
   onRename,
   isSuspended,
   serverStatus,
+  subdomain,
 }: Props) {
   const queryClient = useQueryClient();
+  const [subdomainInput, setSubdomainInput] = useState(subdomain ?? '');
+
+  const updateSubdomainMutation = useMutation({
+    mutationFn: (value: string | null) => serversApi.updateSubdomain(serverId, value),
+    onSuccess: () => {
+      notifySuccess('Subdomain updated');
+      queryClient.invalidateQueries({ queryKey: qk.server(serverId) });
+      queryClient.invalidateQueries({ queryKey: ['servers'] });
+    },
+    onError: (error: any) => notifyError(error?.response?.data?.error || 'Failed to update subdomain'),
+  });
+
+  const isValidSubdomain = (value: string) => {
+    if (!value) return true;
+    return SUBDOMAIN_REGEX.test(value);
+  };
 
   const handleReinstall = async () => {
     try {
@@ -73,6 +94,40 @@ export default function ServerSettingsTab({
               Save
             </button>
           </div>
+        </ServerTabCard>
+        <ServerTabCard>
+          <div className="text-sm font-semibold text-foreground">
+            Subdomain
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Assign a subdomain for easy server access (e.g., my-server).
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+            <input
+              className="min-w-[220px] flex-1 rounded-lg border border-border bg-card px-3 py-2 text-xs text-foreground transition-all duration-300 focus:border-primary focus:outline-none disabled:opacity-60"
+              value={subdomainInput}
+              onChange={(event) => setSubdomainInput(event.target.value)}
+              placeholder="my-server"
+              disabled={isSuspended || updateSubdomainMutation.isPending}
+            />
+            <button
+              type="button"
+              className="rounded-md bg-primary px-3 py-2 font-semibold text-primary-foreground shadow-lg shadow-primary-500/20 transition-all duration-300 hover:bg-primary/90 disabled:opacity-60"
+              onClick={() => updateSubdomainMutation.mutate(subdomainInput.trim() || null)}
+              disabled={
+                updateSubdomainMutation.isPending ||
+                isSuspended ||
+                !isValidSubdomain(subdomainInput.trim())
+              }
+            >
+              Save
+            </button>
+          </div>
+          {subdomainInput && !isValidSubdomain(subdomainInput.trim()) && (
+            <p className="mt-1 text-[11px] text-destructive">
+              Invalid subdomain format. Use lowercase letters, numbers, and hyphens only.
+            </p>
+          )}
         </ServerTabCard>
         <ServerTabCard>
           <div className="text-sm font-semibold text-foreground">

--- a/catalyst-frontend/src/hooks/useAdmin.ts
+++ b/catalyst-frontend/src/hooks/useAdmin.ts
@@ -128,6 +128,14 @@ export function useOidcConfig() {
   });
 }
 
+export function useDnsSettings() {
+  return useQuery({
+    queryKey: qk.adminDnsSettings(),
+    queryFn: adminApi.getDnsSettings,
+    refetchInterval: 30000,
+  });
+}
+
 export function useSystemErrors(params?: {
   page?: number;
   limit?: number;

--- a/catalyst-frontend/src/lib/queryKeys.ts
+++ b/catalyst-frontend/src/lib/queryKeys.ts
@@ -80,6 +80,7 @@ export const qk = {
   adminRoles: () => ['admin-roles'] as const,
   adminSmtp: () => ['admin-smtp'] as const,
   adminModManager: () => ['admin-mod-manager'] as const,
+  adminDnsSettings: () => ['admin-dns-settings'] as const,
   adminSecuritySettings: () => ['admin-security-settings'] as const,
   adminAuthLockouts: (params?: Record<string, unknown>) => ['admin-auth-lockouts', params ?? null] as const,
   adminSystemErrors: (params?: Record<string, unknown>) => ['admin-system-errors', params ?? null] as const,

--- a/catalyst-frontend/src/pages/admin/SystemPage.tsx
+++ b/catalyst-frontend/src/pages/admin/SystemPage.tsx
@@ -18,7 +18,7 @@ import {
   AlertTriangle,
   ArrowUpCircle,
 } from 'lucide-react';
-import { useAdminHealth, useAdminStats, useModManagerSettings, useSmtpSettings } from '../../hooks/useAdmin';
+import { useAdminHealth, useAdminStats, useDnsSettings, useModManagerSettings, useSmtpSettings } from '../../hooks/useAdmin';
 import UpdateSettings from '../../components/admin/UpdateSettings';
 import { adminApi } from '../../services/api/admin';
 import { notifyError, notifySuccess } from '../../utils/notify';
@@ -116,6 +116,7 @@ function SystemPage() {
   const { data: health } = useAdminHealth();
   const { data: smtpSettings } = useSmtpSettings();
   const { data: modManagerSettings } = useModManagerSettings();
+  const { data: dnsSettings } = useDnsSettings();
 
   const [smtpHost, setSmtpHost] = useState('');
   const [smtpPort, setSmtpPort] = useState('587');
@@ -130,6 +131,11 @@ function SystemPage() {
   const [smtpMaxMessages, setSmtpMaxMessages] = useState('');
   const [curseforgeApiKey, setCurseforgeApiKey] = useState('');
   const [modrinthApiKey, setModrinthApiKey] = useState('');
+  const [dnsEnabled, setDnsEnabled] = useState(false);
+  const [dnsProvider, setDnsProvider] = useState('cloudflare');
+  const [dnsBaseDomain, setDnsBaseDomain] = useState('');
+  const [dnsCloudflareApiToken, setDnsCloudflareApiToken] = useState('');
+  const [dnsCloudflareZoneId, setDnsCloudflareZoneId] = useState('');
 
   const updateSmtpMutation = useMutation({
     mutationFn: () =>
@@ -151,6 +157,22 @@ function SystemPage() {
       queryClient.invalidateQueries({ queryKey: qk.adminSmtp() });
     },
     onError: (error: any) => notifyError(error?.response?.data?.error || 'Failed to update SMTP settings'),
+  });
+
+  const updateDnsMutation = useMutation({
+    mutationFn: () =>
+      adminApi.updateDnsSettings({
+        enabled: dnsEnabled,
+        provider: dnsProvider.trim() || null,
+        baseDomain: dnsBaseDomain.trim() || null,
+        cloudflareApiToken: dnsCloudflareApiToken.trim() || null,
+        cloudflareZoneId: dnsCloudflareZoneId.trim() || null,
+      }),
+    onSuccess: () => {
+      notifySuccess('DNS settings updated');
+      queryClient.invalidateQueries({ queryKey: qk.adminDnsSettings() });
+    },
+    onError: (error: any) => notifyError(error?.response?.data?.error || 'Failed to update DNS settings'),
   });
 
   const updateModManagerMutation = useMutation({
@@ -194,6 +216,16 @@ function SystemPage() {
     setCurseforgeApiKey(modManagerSettings.curseforgeApiKey ?? '');
     setModrinthApiKey(modManagerSettings.modrinthApiKey ?? '');
   }, [modManagerSettings]);
+
+  useEffect(() => {
+    if (!dnsSettings) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setDnsEnabled(Boolean(dnsSettings.enabled));
+    setDnsProvider(dnsSettings.provider ?? 'cloudflare');
+    setDnsBaseDomain(dnsSettings.baseDomain ?? '');
+    setDnsCloudflareApiToken(dnsSettings.cloudflareApiToken ?? '');
+    setDnsCloudflareZoneId(dnsSettings.cloudflareZoneId ?? '');
+  }, [dnsSettings]);
 
   const isHealthy = health?.status === 'healthy';
   const dbStatus = health?.database ?? 'checking';
@@ -388,6 +420,55 @@ function SystemPage() {
               </span>
               <Input type="password" value={modrinthApiKey} onChange={(e) => setModrinthApiKey(e.target.value)} placeholder="••••••••" />
             </label>
+          </div>
+        </Section>
+
+        {/* ── DNS Configuration ── */}
+        <Section
+          title="DNS Configuration"
+          subtitle="Configure DNS provider integration for automatic subdomain management."
+          icon={<Globe className="h-4 w-4 text-info dark:text-info" />}
+          iconColor="bg-info/10 dark:bg-blue-900/30"
+          footer={
+            <Button size="sm" disabled={updateDnsMutation.isPending} onClick={() => updateDnsMutation.mutate()}>
+              {updateDnsMutation.isPending ? 'Saving…' : 'Save DNS settings'}
+            </Button>
+          }
+        >
+          <div className="space-y-4">
+            <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-pointer">
+              <input
+                type="checkbox"
+                checked={dnsEnabled}
+                onChange={(e) => setDnsEnabled(e.target.checked)}
+                className="h-4 w-4 rounded border-border bg-card text-primary-600 dark:border-border dark:bg-surface-1 dark:text-primary-400"
+              />
+              Enable DNS integration
+            </label>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <label className="block space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">Provider</span>
+                <select
+                  value={dnsProvider}
+                  onChange={(e) => setDnsProvider(e.target.value)}
+                  className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground dark:bg-surface-1"
+                >
+                  <option value="cloudflare">Cloudflare</option>
+                </select>
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">Base domain</span>
+                <Input value={dnsBaseDomain} onChange={(e) => setDnsBaseDomain(e.target.value)} placeholder="servers.example.com" />
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">Cloudflare API token</span>
+                <Input type="password" value={dnsCloudflareApiToken} onChange={(e) => setDnsCloudflareApiToken(e.target.value)} placeholder="••••••••" />
+              </label>
+              <label className="block space-y-1">
+                <span className="text-xs font-medium text-muted-foreground">Cloudflare Zone ID</span>
+                <Input value={dnsCloudflareZoneId} onChange={(e) => setDnsCloudflareZoneId(e.target.value)} placeholder="zone-id" />
+              </label>
+            </div>
           </div>
         </Section>
 

--- a/catalyst-frontend/src/pages/servers/ServerDetailsPage.tsx
+++ b/catalyst-frontend/src/pages/servers/ServerDetailsPage.tsx
@@ -1171,6 +1171,7 @@ function ServerDetailsPage() {
               onRename={() => renameServerMutation.mutate()}
               isSuspended={isSuspended}
               serverStatus={server.status}
+              subdomain={server.subdomain ?? null}
             />
           )}
           </Suspense>

--- a/catalyst-frontend/src/services/api/admin.ts
+++ b/catalyst-frontend/src/services/api/admin.ts
@@ -11,6 +11,7 @@ import type {
   AdminNodesResponse,
   AuditLogsResponse,
   DatabaseHost,
+  DnsSettings,
   ModManagerSettings,
   SmtpSettings,
   SecuritySettings,
@@ -204,6 +205,14 @@ export const adminApi = {
   },
   updateModManagerSettings: async (payload: ModManagerSettings) => {
     const data = await apiClient.put<ApiResponse<void>>('/api/admin/mod-manager', payload);
+    return data;
+  },
+  getDnsSettings: async () => {
+    const data = await apiClient.get<ApiResponse<DnsSettings>>('/api/admin/dns-settings');
+    return data.data;
+  },
+  updateDnsSettings: async (payload: DnsSettings) => {
+    const data = await apiClient.put<ApiResponse<void>>('/api/admin/dns-settings', payload);
     return data;
   },
   listAuthLockouts: async (params?: { page?: number; limit?: number; search?: string }) => {

--- a/catalyst-frontend/src/services/api/servers.ts
+++ b/catalyst-frontend/src/services/api/servers.ts
@@ -308,4 +308,8 @@ export const serversApi = {
     );
     return data;
   },
+  updateSubdomain: async (id: string, subdomain: string | null) => {
+    const data = await apiClient.put<ApiResponse<Server>>(`/api/servers/${id}`, { subdomain });
+    return data.data;
+  },
 };

--- a/catalyst-frontend/src/services/api/templates.ts
+++ b/catalyst-frontend/src/services/api/templates.ts
@@ -36,6 +36,8 @@ export const templatesApi = {
     allocatedCpuCores: number;
     features?: Template['features'];
     nestId?: string | null;
+    srvService?: string | null;
+    srvProtocol?: string | null;
   }) => {
     const data = await apiClient.post<ApiResponse<Template>>('/api/templates', payload);
     return data.data;
@@ -61,6 +63,8 @@ export const templatesApi = {
       allocatedCpuCores: number;
       features?: Template['features'];
       nestId?: string | null;
+      srvService?: string | null;
+      srvProtocol?: string | null;
     }>,
   ) => {
     const data = await apiClient.put<ApiResponse<Template>>(

--- a/catalyst-frontend/src/types/admin.ts
+++ b/catalyst-frontend/src/types/admin.ts
@@ -301,6 +301,14 @@ export interface RoleUsersResponse {
   permissions: string[];
 }
 
+export interface DnsSettings {
+  enabled: boolean;
+  provider: string | null;
+  baseDomain: string | null;
+  cloudflareApiToken: string | null;
+  cloudflareZoneId: string | null;
+}
+
 export interface UpdateStatusResponse {
   currentVersion: string;
   latestVersion: string;

--- a/catalyst-frontend/src/types/server.ts
+++ b/catalyst-frontend/src/types/server.ts
@@ -36,6 +36,7 @@ export interface Server {
   nodeName?: string;
   primaryPort?: number;
   primaryIp?: string | null;
+  subdomain?: string | null;
   portBindings?: Record<number, number>;
   networkMode?: string;
   environment?: Record<string, string>;
@@ -121,6 +122,7 @@ export interface Server {
     hostNetworkIp?: string | null;
     host?: string | null;
     port?: number | null;
+    subdomain?: string | null;
   };
   /** Effective permissions for the current user on this server */
   effectivePermissions?: string[];
@@ -146,6 +148,7 @@ export interface CreateServerPayload {
   databaseAllocation?: number;
   primaryPort: number;
   primaryIp?: string | null;
+  subdomain?: string | null;
   allocationId?: string;
   portBindings?: Record<number, number>;
   networkMode?: string;
@@ -162,6 +165,7 @@ export interface UpdateServerPayload {
   allocatedDiskMb?: number;
   primaryPort?: number;
   primaryIp?: string | null;
+  subdomain?: string | null;
   allocationId?: string;
   portBindings?: Record<number, number>;
   backupAllocationMb?: number;

--- a/catalyst-frontend/src/types/template.ts
+++ b/catalyst-frontend/src/types/template.ts
@@ -82,4 +82,6 @@ export interface Template {
   allocatedMemoryMb: number;
   allocatedCpuCores: number;
   features?: TemplateFeatures;
+  srvService?: string | null;
+  srvProtocol?: string;
 }


### PR DESCRIPTION
Closes #112

## Summary
Adds the ability to use Cloudflare (and extensible to other DNS providers) to map subdomains to servers instead of raw IP addresses.

## Changes
- **Database**: Added \`subdomain\` field to \`Server\` model (unique, validated) and DNS provider settings to \`SystemSetting\`
- **Backend**: Created \`dns-sync.ts\` service for Cloudflare A-record CRUD; added \`CATALYST_SUBDOMAIN\` env var injection at server startup
- **API**: New admin endpoints for DNS configuration (\`GET/PUT /api/admin/dns-settings\`); subdomain validation in server create/update
- **Frontend**:
  - \`ServerCard\` displays subdomain badge when available
  - New subdomain editor in server **Settings** tab
  - New **DNS Configuration** section in admin **System** page
- **Tests**: Added \`subdomain-support.test.ts\` covering validation, DNS sync create/update/delete, and unsupported provider handling
- **Migration**: \`20260504150000_add_subdomain_support\`

## Usage
1. Admin configures DNS provider in System → DNS Configuration (Cloudflare API token + Zone ID + base domain)
2. Server owner sets a subdomain in Server Settings → Subdomain
3. Backend automatically syncs an A record pointing the subdomain to the server's primary IP

## Example
Instead of \`192.168.1.78:25565\`, users get \`minecraft.karutoil.site\`