### PR TITLE
feat: automated Docker container testing with E2E suite

### DIFF
--- a/.github/workflows/docker-e2e.yml
+++ b/.github/workflows/docker-e2e.yml
@@ -1,0 +1,81 @@
+name: CI/CD - Docker E2E Tests
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'catalyst-backend/**'
+      - 'catalyst-frontend/**'
+      - 'catalyst-agent/**'
+      - 'catalyst-docker/**'
+      - 'tests/**'
+      - '.github/workflows/docker-e2e.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'catalyst-backend/**'
+      - 'catalyst-frontend/**'
+      - 'catalyst-agent/**'
+      - 'catalyst-docker/**'
+      - 'tests/**'
+
+permissions:
+  contents: read
+
+env:
+  TEST_LOG_DIR: /tmp/catalyst-docker-tests
+
+jobs:
+  docker-e2e-tests:
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Docker Buildx
+        uses: useblacksmith/setup-docker-builder@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v5
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq curl openssl openssh-client
+
+      - name: Run Docker E2E Tests
+        working-directory: tests
+        run: |
+          ./run-docker-tests.sh --verbose
+        timeout-minutes: 30
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-e2e-logs-${{ github.run_id }}
+          path: /tmp/catalyst-docker-tests/
+          retention-days: 7
+
+      - name: Upload container logs on failure
+        if: failure()
+        run: |
+          mkdir -p /tmp/catalyst-docker-tests/containers
+          cd catalyst-docker
+          for container in $(docker compose -f docker-compose.yml -f docker-compose.test.yml ps -q 2>/dev/null || true); do
+            name=$(docker inspect --format='{{.Name}}' "$container" | sed 's/^\///')
+            docker logs "$container" > "/tmp/catalyst-docker-tests/containers/${name}.log" 2>&1 || true
+          done
+          docker compose -f docker-compose.yml -f docker-compose.test.yml logs > /tmp/catalyst-docker-tests/container-logs.txt 2>/dev/null || true
+
+      - name: Cleanup on failure
+        if: failure()
+        run: |
+          cd catalyst-docker
+          docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test down -v 2>/dev/null || true

--- a/catalyst-docker/docker-compose.test.yml
+++ b/catalyst-docker/docker-compose.test.yml
@@ -1,0 +1,161 @@
+# =============================================================================
+# Catalyst — Docker Compose Test Override
+#
+# Extends docker-compose.yml with build contexts and test-specific settings.
+# Used by the Docker E2E test suite to build and test local images.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.test.yml up -d
+# =============================================================================
+
+services:
+  # ===========================================================================
+  # PostgreSQL (test-optimized)
+  # ===========================================================================
+  postgres:
+    ports:
+      - "${POSTGRES_PORT:-127.0.0.1:5432}:5432"
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-catalyst_test_password}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U catalyst"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  # ===========================================================================
+  # Redis (test-optimized)
+  # ===========================================================================
+  redis:
+    ports:
+      - "${REDIS_PORT:-127.0.0.1:6379}:6379"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-}
+    healthcheck:
+      test: "redis-cli ping | grep PONG"
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  # ===========================================================================
+  # Backend (built from local source)
+  # ===========================================================================
+  backend:
+    build:
+      context: ..
+      dockerfile: catalyst-backend/Dockerfile
+    image: catalyst-backend:test
+    container_name: catalyst-backend-test
+    ports:
+      - "${BACKEND_PORT:-127.0.0.1:3000}:3000"
+      - "${SFTP_PORT:-0.0.0.0:2022}:2022"
+    environment:
+      NODE_ENV: test
+      LOG_LEVEL: debug
+      DATABASE_URL: postgresql://catalyst:${POSTGRES_PASSWORD}@postgres:5432/catalyst_db
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
+      BETTER_AUTH_URL: ${PUBLIC_URL:-http://localhost}
+      PASSKEY_RP_ID: ${PASSKEY_RP_ID:-localhost}
+      CORS_ORIGIN: ${PUBLIC_URL:-http://localhost}
+      FRONTEND_URL: ${PUBLIC_URL:-http://localhost}
+      BACKEND_EXTERNAL_ADDRESS: ${PUBLIC_URL:-http://localhost}
+      BACKEND_URL: ${PUBLIC_URL:-http://localhost}
+      SFTP_ENABLED: ${SFTP_ENABLED:-true}
+      SFTP_PORT: "2022"
+      SFTP_MAX_FILE_SIZE: ${SFTP_MAX_FILE_SIZE:-104857600}
+      SFTP_HOST_KEY: ${SFTP_HOST_KEY:-}
+      SFTP_HOST_KEY_BASE64: ${SFTP_HOST_KEY_BASE64:-}
+      DEPLOY_SCRIPT_PATH: /scripts/deploy-agent.sh
+      SERVER_DATA_DIR: /var/lib/catalyst/servers
+      BACKUP_DIR: /var/lib/catalyst/backups
+      BACKUP_STORAGE_MODE: ${BACKUP_STORAGE_MODE:-local}
+      BACKUP_STREAM_DIR: /tmp/catalyst-backup-stream
+      BACKUP_TRANSFER_DIR: /tmp/catalyst-backup-transfer
+      APP_NAME: ${APP_NAME:-Catalyst}
+      ENABLE_COMPRESSION: ${ENABLE_COMPRESSION:-true}
+      WEBHOOK_URLS: ${WEBHOOK_URLS:-}
+      WEBHOOK_SECRET: ${WEBHOOK_SECRET:-}
+      SUSPENSION_ENFORCED: ${SUSPENSION_ENFORCED:-true}
+      SUSPENSION_DELETE_BLOCKED: ${SUSPENSION_DELETE_BLOCKED:-false}
+      SUSPENSION_DELETE_POLICY: ${SUSPENSION_DELETE_POLICY:-keep}
+      PLUGINS_DIR: /var/lib/catalyst/plugins
+      WHMCS_OIDC_CLIENT_ID: ${WHMCS_OIDC_CLIENT_ID:-}
+      WHMCS_OIDC_CLIENT_SECRET: ${WHMCS_OIDC_CLIENT_SECRET:-}
+      WHMCS_OIDC_DISCOVERY_URL: ${WHMCS_OIDC_DISCOVERY_URL:-}
+      PAYMENTER_OIDC_CLIENT_ID: ${PAYMENTER_OIDC_CLIENT_ID:-}
+      PAYMENTER_OIDC_CLIENT_SECRET: ${PAYMENTER_OIDC_CLIENT_SECRET:-}
+      PAYMENTER_OIDC_DISCOVERY_URL: ${PAYMENTER_OIDC_DISCOVERY_URL:-}
+      AUTO_UPDATE_ENABLED: ${AUTO_UPDATE_ENABLED:-false}
+      AUTO_UPDATE_INTERVAL_MS: ${AUTO_UPDATE_INTERVAL_MS:-3600000}
+      AUTO_UPDATE_AUTO_TRIGGER: ${AUTO_UPDATE_AUTO_TRIGGER:-false}
+      CONSOLE_OUTPUT_BYTE_LIMIT_BYTES: ${CONSOLE_OUTPUT_BYTE_LIMIT_BYTES:-524288}
+      MAX_DISK_MB: ${MAX_DISK_MB:-1048576}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 1G
+        reservations:
+          cpus: '0.5'
+          memory: 256M
+
+  # ===========================================================================
+  # Frontend (built from local source)
+  # ===========================================================================
+  frontend:
+    build:
+      context: ..
+      dockerfile: catalyst-frontend/Dockerfile
+    image: catalyst-frontend:test
+    container_name: catalyst-frontend-test
+    ports:
+      - "${FRONTEND_PORT:-127.0.0.1:8080}:80"
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+
+  # ===========================================================================
+  # Agent (optional — for full E2E testing with agent connectivity)
+  # ===========================================================================
+  agent:
+    build:
+      context: ../catalyst-agent
+      dockerfile: Dockerfile
+    image: catalyst-agent:test
+    container_name: catalyst-agent-test
+    depends_on:
+      backend:
+        condition: service_healthy
+    environment:
+      RUST_LOG: info
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - agent-config:/opt/catalyst-agent
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    # Agent starts paused — tests will configure and start it as needed
+    entrypoint: ["sh", "-c", "sleep infinity"]
+
+volumes:
+  agent-config:
+    driver: local

--- a/tests/DOCKER_TESTING.md
+++ b/tests/DOCKER_TESTING.md
@@ -1,0 +1,287 @@
+# Docker Automated Testing
+
+This document describes the Docker-based E2E testing system for Catalyst. It builds local Docker images and runs the full test suite against containerized services.
+
+## Quick Start
+
+```bash
+# Run the full Docker E2E test suite
+cd tests
+./run-docker-tests.sh
+```
+
+## Prerequisites
+
+- **Docker** 20.10+ (with BuildKit support)
+- **Docker Compose** 2.0+
+- **bash** 4.0+
+- **jq** — JSON processing
+- **curl** — HTTP requests
+- **openssl** — Secret generation
+- **ssh-keygen** — SFTP host key generation
+
+Install prerequisites on Ubuntu/Debian:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y jq curl openssl openssh-client
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    run-docker-tests.sh                       │
+│  (Orchestrator — CLI, logging, three-phase execution)       │
+└─────────────────────────────────────────────────────────────┘
+                              │
+              ┌───────────────┼───────────────┐
+              ▼               ▼               ▼
+        ┌─────────┐    ┌──────────┐    ┌──────────┐
+        │ Phase 1 │    │ Phase 2  │    │ Phase 3  │
+        │ Build   │ →  │ Setup    │ →  │ Run      │
+        │ Images  │    │ Environment│   │ Tests    │
+        └─────────┘    └──────────┘    └──────────┘
+              │               │               │
+              ▼               ▼               ▼
+        docker compose    docker-env.sh   run-all-tests.sh
+        build             .env.test       (14 test suites)
+```
+
+## Running Tests Locally
+
+### Full Suite
+
+```bash
+cd tests
+./run-docker-tests.sh
+```
+
+This will:
+1. Build `catalyst-backend:test` and `catalyst-frontend:test` images from local source
+2. Generate a test `.env` file with randomized ports and secrets
+3. Start all services with Docker Compose
+4. Wait for healthchecks to pass
+5. Run database migrations and seed data
+6. Execute all 14 core E2E test suites
+7. Clean up containers and volumes
+
+### Single Test Suite
+
+```bash
+./run-docker-tests.sh --suite 01-auth.test.sh
+```
+
+### Skip Image Build (Use Existing)
+
+```bash
+./run-docker-tests.sh --skip-build
+```
+
+Useful when you've already built the images and want to re-run tests quickly.
+
+### Verbose Output
+
+```bash
+./run-docker-tests.sh --verbose
+```
+
+Shows all test output in real-time instead of saving to log files.
+
+### Keep Containers for Debugging
+
+```bash
+./run-docker-tests.sh --skip-cleanup
+```
+
+Leaves containers running after tests so you can inspect them:
+
+```bash
+cd catalyst-docker
+docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test ps
+docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test logs backend
+```
+
+### Stop on First Failure
+
+```bash
+./run-docker-tests.sh --stop-on-failure
+```
+
+## Environment Variables
+
+The orchestrator automatically generates a test environment file (`catalyst-docker/.env.test`) with:
+
+| Variable | Description |
+|----------|-------------|
+| `BACKEND_PORT` | Randomized backend port (20000–60000) |
+| `FRONTEND_PORT` | Randomized frontend port |
+| `POSTGRES_PORT` | Randomized PostgreSQL port |
+| `REDIS_PORT` | Randomized Redis port |
+| `SFTP_PORT` | Randomized SFTP port |
+| `BETTER_AUTH_SECRET` | Secure random secret (base64, 32 bytes) |
+| `POSTGRES_PASSWORD` | Secure random password |
+| `REDIS_PASSWORD` | Secure random password |
+| `PUBLIC_URL` | Points to `http://127.0.0.1:<frontend_port>` |
+| `SFTP_HOST_KEY` | Auto-generated ED25519 host key |
+
+You can also set these environment variables before running:
+
+| Variable | Description |
+|----------|-------------|
+| `TEST_LOG_DIR` | Where logs are saved (default: `/tmp/catalyst-docker-tests`) |
+| `BACKEND_URL` | Auto-set by the orchestrator — do not override manually |
+
+## Test Logs
+
+All logs are saved to `TEST_LOG_DIR` (default: `/tmp/catalyst-docker-tests`):
+
+```
+/tmp/catalyst-docker-tests/
+├── orchestrator.log       # Main orchestrator output
+├── build-backend.log      # Backend image build output
+├── build-frontend.log     # Frontend image build output
+├── build-agent.log        # Agent image build output
+├── db-migration.log       # Database migration output
+├── db-seed.log            # Database seed output
+├── cleanup.log            # Cleanup output
+├── 01-auth.test.sh.log    # Individual test suite logs
+├── 02-templates.test.sh.log
+└── ...
+```
+
+## CI Integration
+
+The GitHub Actions workflow (`.github/workflows/docker-e2e.yml`) runs automatically on:
+
+- **Pull requests** to `main` or `develop` (when relevant files change)
+- **Pushes** to `main` (when relevant files change)
+
+The workflow:
+1. Checks out the repository
+2. Sets up Docker Buildx with layer caching
+3. Installs dependencies (`jq`, `curl`, `openssl`)
+4. Runs the full Docker E2E test suite with `--verbose`
+5. Uploads test logs as artifacts (always)
+6. Captures container logs on failure
+7. Cleans up containers on failure
+
+### Workflow Triggers
+
+The workflow triggers when any of these paths change:
+
+```yaml
+paths:
+  - 'catalyst-backend/**'
+  - 'catalyst-frontend/**'
+  - 'catalyst-agent/**'
+  - 'catalyst-docker/**'
+  - 'tests/**'
+  - '.github/workflows/docker-e2e.yml'
+```
+
+## Files Reference
+
+| File | Purpose |
+|------|---------|
+| `tests/run-docker-tests.sh` | Main orchestrator script |
+| `tests/lib/docker-env.sh` | Environment generation library |
+| `tests/lib/utils.sh` | Docker helper functions (wait, logs, cleanup) |
+| `catalyst-docker/docker-compose.test.yml` | Test-specific Compose override |
+| `catalyst-docker/.env.test` | Auto-generated test environment (temporary) |
+| `.github/workflows/docker-e2e.yml` | GitHub Actions CI workflow |
+| `tests/DOCKER_TESTING.md` | This documentation |
+
+## Troubleshooting
+
+### Port Conflicts
+
+If you see "port already allocated" errors, the orchestrator will try up to 50 random ports per service. If conflicts persist:
+
+```bash
+# Check what's using the ports
+sudo ss -tlnp | grep -E '20000|30000|40000|50000|60000'
+
+# Or manually specify ports in catalyst-docker/.env.test
+```
+
+### Build Failures
+
+If image builds fail, check the build logs:
+
+```bash
+cat /tmp/catalyst-docker-tests/build-backend.log
+cat /tmp/catalyst-docker-tests/build-frontend.log
+```
+
+Common issues:
+- Missing `bun.lock` or `package.json` changes not committed
+- Docker daemon not running
+- Insufficient disk space (`docker system df`)
+
+### Services Not Healthy
+
+If services fail healthchecks:
+
+```bash
+# Run with --skip-cleanup and inspect
+cd catalyst-docker
+docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test ps
+docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test logs backend
+```
+
+### Database Migration Failures
+
+If migrations fail, the backend container may not have connectivity to postgres:
+
+```bash
+# Test connectivity from backend container
+docker exec catalyst-backend-test pg_isready -h postgres -U catalyst
+```
+
+## Development Tips
+
+### Iterating Quickly
+
+For rapid iteration during development:
+
+```bash
+# Build once, test many times
+cd tests
+./run-docker-tests.sh --skip-build --skip-cleanup
+
+# Then run individual suites against running containers
+BACKEND_URL=$(./lib/docker-env.sh get_test_backend_url 2>/dev/null || echo "http://127.0.0.1:3000")
+export BACKEND_URL
+bash 01-auth.test.sh
+```
+
+### Testing Agent-Related Suites
+
+Some test suites (07, 21, 24) require the agent container. The orchestrator builds the agent image but starts it in a paused state (`sleep infinity`). Tests that need the agent will configure and start it dynamically.
+
+### Adding New Test Suites
+
+To add a new test suite:
+
+1. Create `tests/XX-your-suite.test.sh`
+2. Source `lib/utils.sh` and `config.env`
+3. Use the assertion helpers (`assert_equals`, `assert_http_code`, etc.)
+4. Call `print_test_summary` at the end
+5. Add the suite to `TEST_SUITES` in `run-all-tests.sh`
+
+## Security Considerations
+
+- Test secrets are auto-generated per-run and never committed
+- SFTP host keys are generated fresh for each test run
+- Containers are isolated with randomized ports
+- All test data is destroyed on cleanup (`docker compose down -v`)
+- The `.env.test` file is created in `.gitignore` territory (it is explicitly removed on cleanup)
+
+## Future Enhancements
+
+- [ ] Parallel test suite execution
+- [ ] Agent container automatic startup for agent-dependent tests
+- [ ] Multi-arch image builds (ARM64 + AMD64)
+- [ ] Test result reporting to GitHub PR comments
+- [ ] Snapshot testing for container image sizes

--- a/tests/lib/docker-env.sh
+++ b/tests/lib/docker-env.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+#
+# Docker Test Environment Generator
+# Creates test-specific .env file with randomized ports and secrets
+#
+
+set -euo pipefail
+
+# Source utility functions (colors, logging, etc.)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=utils.sh
+source "$SCRIPT_DIR/utils.sh" 2>/dev/null || true
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+# Port ranges for randomization
+PORT_MIN=20000
+PORT_MAX=60000
+
+# Default output file (relative to catalyst-docker directory)
+DEFAULT_OUTPUT_FILE="../catalyst-docker/.env.test"
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+# Generate a random port number within range, checking for availability
+_generate_random_port() {
+    local port
+    local attempts=0
+    local max_attempts=50
+
+    while [ $attempts -lt $max_attempts ]; do
+        port=$(shuf -i "${PORT_MIN}-${PORT_MAX}" -n 1)
+        # Check if port is available on both TCP and UDP
+        if ! ss -tln | awk '{print $4}' | grep -qE "(:|${port}$)" 2>/dev/null; then
+            echo "$port"
+            return 0
+        fi
+        ((attempts++)) || true
+    done
+
+    # Fallback: just return a random port without checking
+    shuf -i "${PORT_MIN}-${PORT_MAX}" -n 1
+}
+
+# Generate a secure random secret (base64)
+_generate_secret() {
+    local length="${1:-32}"
+    openssl rand -base64 "$length" 2>/dev/null || cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w "$length" | head -n 1
+}
+
+# Generate an SFTP host key (ed25519)
+_generate_sftp_host_key() {
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    ssh-keygen -t ed25519 -f "$tmp_dir/host_key" -N "" -C "catalyst-test" > /dev/null 2>&1
+    cat "$tmp_dir/host_key"
+    rm -rf "$tmp_dir"
+}
+
+# ============================================================================
+# Main Functions
+# ============================================================================
+
+# Generate test environment file with randomized values
+# Usage: generate_test_env [output_file]
+generate_test_env() {
+    local output_file="${1:-$DEFAULT_OUTPUT_FILE}"
+    local output_dir
+    output_dir=$(dirname "$output_file")
+
+    # Ensure output directory exists
+    mkdir -p "$output_dir"
+
+    log_info "Generating test environment file: $output_file"
+
+    # Generate random ports
+    local postgres_port backend_port frontend_port redis_port sftp_port
+    postgres_port=$(_generate_random_port)
+    backend_port=$(_generate_random_port)
+    frontend_port=$(_generate_random_port)
+    redis_port=$(_generate_random_port)
+    sftp_port=$(_generate_random_port)
+
+    # Ensure all ports are unique
+    while [ "$postgres_port" = "$backend_port" ] || [ "$postgres_port" = "$frontend_port" ] || \
+          [ "$postgres_port" = "$redis_port" ] || [ "$postgres_port" = "$sftp_port" ]; do
+        postgres_port=$(_generate_random_port)
+    done
+    while [ "$backend_port" = "$frontend_port" ] || [ "$backend_port" = "$redis_port" ] || \
+          [ "$backend_port" = "$sftp_port" ]; do
+        backend_port=$(_generate_random_port)
+    done
+    while [ "$frontend_port" = "$redis_port" ] || [ "$frontend_port" = "$sftp_port" ]; do
+        frontend_port=$(_generate_random_port)
+    done
+    while [ "$redis_port" = "$sftp_port" ]; do
+        redis_port=$(_generate_random_port)
+    done
+
+    # Generate secrets
+    local better_auth_secret postgres_password redis_password sftp_host_key
+    better_auth_secret=$(_generate_secret 32)
+    postgres_password=$(_generate_secret 24)
+    redis_password=$(_generate_secret 24)
+    sftp_host_key=$(_generate_sftp_host_key)
+
+    # Base64 encode the SFTP host key for env var
+    local sftp_host_key_base64
+    sftp_host_key_base64=$(echo "$sftp_host_key" | base64 -w 0)
+
+    # Construct public URL (frontend port on localhost)
+    local public_url
+    public_url="http://127.0.0.1:${frontend_port}"
+
+    # Write the environment file
+    cat > "$output_file" <<EOF
+# =============================================================================
+# Catalyst — Test Environment (Auto-generated)
+# Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+# DO NOT EDIT MANUALLY — Regenerate with: ./run-docker-tests.sh
+# =============================================================================
+
+NODE_ENV=test
+APP_NAME=Catalyst Test
+TZ=UTC
+LOG_LEVEL=debug
+
+# --- Ports (randomized to avoid conflicts) -----------------------------------
+POSTGRES_PORT=127.0.0.1:${postgres_port}
+REDIS_PORT=127.0.0.1:${redis_port}
+BACKEND_PORT=127.0.0.1:${backend_port}
+FRONTEND_PORT=127.0.0.1:${frontend_port}
+SFTP_PORT=0.0.0.0:${sftp_port}
+
+# --- PostgreSQL --------------------------------------------------------------
+POSTGRES_USER=catalyst
+POSTGRES_PASSWORD=${postgres_password}
+POSTGRES_DB=catalyst_db
+
+# --- Redis -------------------------------------------------------------------
+REDIS_PASSWORD=${redis_password}
+
+# --- Auth --------------------------------------------------------------------
+BETTER_AUTH_SECRET=${better_auth_secret}
+PASSKEY_RP_ID=localhost
+
+# --- Public URL --------------------------------------------------------------
+# This is the single source of truth for CORS, auth, and deploy URLs.
+PUBLIC_URL=${public_url}
+
+# --- SFTP --------------------------------------------------------------------
+SFTP_ENABLED=true
+# SFTP_HOST_KEY is left empty — backend auto-generates from SFTP_HOST_KEY_BASE64
+SFTP_HOST_KEY=
+SFTP_HOST_KEY_BASE64=${sftp_host_key_base64}
+SFTP_MAX_FILE_SIZE=104857600
+
+# --- Backups -----------------------------------------------------------------
+BACKUP_STORAGE_MODE=local
+
+# --- Performance tuning ------------------------------------------------------
+CONSOLE_OUTPUT_BYTE_LIMIT_BYTES=524288
+MAX_DISK_MB=1048576
+
+# --- Webhooks (disabled in tests) --------------------------------------------
+# WEBHOOK_URLS=
+# WEBHOOK_SECRET=
+
+# --- Suspension --------------------------------------------------------------
+SUSPENSION_ENFORCED=true
+SUSPENSION_DELETE_BLOCKED=false
+SUSPENSION_DELETE_POLICY=keep
+
+# --- OAuth (disabled in tests) -----------------------------------------------
+# WHMCS_OIDC_CLIENT_ID=
+# WHMCS_OIDC_CLIENT_SECRET=
+# WHMCS_OIDC_DISCOVERY_URL=
+# PAYMENTER_OIDC_CLIENT_ID=
+# PAYMENTER_OIDC_CLIENT_SECRET=
+# PAYMENTER_OIDC_DISCOVERY_URL=
+
+# --- Auto Updater (disabled in tests) ----------------------------------------
+AUTO_UPDATE_ENABLED=false
+AUTO_UPDATE_INTERVAL_MS=3600000
+AUTO_UPDATE_AUTO_TRIGGER=false
+EOF
+
+    log_success "Test environment file generated with ${public_url}"
+    log_info "  Backend port: ${backend_port}"
+    log_info "  Frontend port: ${frontend_port}"
+    log_info "  Postgres port: ${postgres_port}"
+    log_info "  Redis port: ${redis_port}"
+    log_info "  SFTP port: ${sftp_port}"
+}
+
+# Get the backend URL from the generated .env.test file
+# Usage: get_test_backend_url [env_file]
+get_test_backend_url() {
+    local env_file="${1:-../catalyst-docker/.env.test}"
+
+    if [ ! -f "$env_file" ]; then
+        echo ""
+        return 1
+    fi
+
+    local backend_port
+    backend_port=$(grep "^BACKEND_PORT=" "$env_file" | cut -d'=' -f2 | sed 's/127.0.0.1://')
+    echo "http://127.0.0.1:${backend_port}"
+}
+
+# Get the frontend URL from the generated .env.test file
+# Usage: get_test_frontend_url [env_file]
+get_test_frontend_url() {
+    local env_file="${1:-../catalyst-docker/.env.test}"
+
+    if [ ! -f "$env_file" ]; then
+        echo ""
+        return 1
+    fi
+
+    local frontend_port
+    frontend_port=$(grep "^FRONTEND_PORT=" "$env_file" | cut -d'=' -f2 | sed 's/127.0.0.1://')
+    echo "http://127.0.0.1:${frontend_port}"
+}
+
+# Get the WebSocket URL from the generated .env.test file
+# Usage: get_test_ws_url [env_file]
+get_test_ws_url() {
+    local env_file="${1:-../catalyst-docker/.env.test}"
+
+    if [ ! -f "$env_file" ]; then
+        echo ""
+        return 1
+    fi
+
+    local backend_port
+    backend_port=$(grep "^BACKEND_PORT=" "$env_file" | cut -d'=' -f2 | sed 's/127.0.0.1://')
+    echo "ws://127.0.0.1:${backend_port}/ws"
+}
+
+# Load environment variables from .env.test file
+# Usage: load_test_env [env_file]
+load_test_env() {
+    local env_file="${1:-../catalyst-docker/.env.test}"
+
+    if [ ! -f "$env_file" ]; then
+        log_error "Test environment file not found: $env_file"
+        return 1
+    fi
+
+    # Export all variables from the file
+    set -a
+    # shellcheck source=/dev/null
+    source "$env_file"
+    set +a
+
+    log_info "Loaded test environment from $env_file"
+}
+
+# Check if all required tools are available for Docker testing
+# Usage: check_docker_prerequisites
+check_docker_prerequisites() {
+    local missing=()
+
+    command -v docker >/dev/null 2>&1 || missing+=("docker")
+    command -v docker compose >/dev/null 2>&1 || missing+=("docker compose")
+    command -v curl >/dev/null 2>&1 || missing+=("curl")
+    command -v jq >/dev/null 2>&1 || missing+=("jq")
+    command -v openssl >/dev/null 2>&1 || missing+=("openssl")
+    command -v ssh-keygen >/dev/null 2>&1 || missing+=("ssh-keygen")
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Missing prerequisites for Docker testing:"
+        for tool in "${missing[@]}"; do
+            log_error "  - $tool"
+        done
+        return 1
+    fi
+
+    # Check Docker daemon is running
+    if ! docker info >/dev/null 2>&1; then
+        log_error "Docker daemon is not running or not accessible"
+        return 1
+    fi
+
+    log_success "All Docker test prerequisites satisfied"
+    return 0
+}

--- a/tests/lib/utils.sh
+++ b/tests/lib/utils.sh
@@ -457,3 +457,106 @@ setup_cleanup_trap() {
     local cleanup_function="$1"
     trap "$cleanup_function" EXIT INT TERM
 }
+
+# ============================================================================
+# Docker Compose Helpers
+# ============================================================================
+
+# Wait for Docker Compose services to be healthy
+# Usage: wait_for_compose_services <compose_dir> [timeout_seconds]
+wait_for_compose_services() {
+    local compose_dir="$1"
+    local timeout="${2:-120}"
+    local elapsed=0
+    local compose_files=""
+
+    # Detect compose files
+    if [ -f "$compose_dir/docker-compose.yml" ] && [ -f "$compose_dir/docker-compose.test.yml" ]; then
+        compose_files="-f $compose_dir/docker-compose.yml -f $compose_dir/docker-compose.test.yml"
+    elif [ -f "$compose_dir/docker-compose.yml" ]; then
+        compose_files="-f $compose_dir/docker-compose.yml"
+    else
+        log_error "No docker-compose.yml found in $compose_dir"
+        return 1
+    fi
+
+    log_info "Waiting for compose services to be healthy (timeout: ${timeout}s)..."
+
+    while [ $elapsed -lt $timeout ]; do
+        local all_healthy=true
+        local services
+        services=$(docker compose $compose_files ps --format json 2>/dev/null | jq -sr '.[] | select(.Health != "healthy" and .Health != "" and .Health != null) | .Name' 2>/dev/null || true)
+
+        if [ -z "$services" ]; then
+            # Also check if any services are still starting (no healthcheck yet)
+            local starting
+            starting=$(docker compose $compose_files ps --format json 2>/dev/null | jq -sr '.[] | select(.State == "running" and (.Health == "" or .Health == null)) | .Name' 2>/dev/null || true)
+
+            if [ -z "$starting" ]; then
+                log_success "All compose services are healthy"
+                return 0
+            fi
+        fi
+
+        sleep 2
+        ((elapsed += 2)) || true
+
+        # Show progress every 10 seconds
+        if [ $((elapsed % 10)) -eq 0 ]; then
+            log_info "  ...waiting (${elapsed}s elapsed)"
+            docker compose $compose_files ps --format "table {{.Name}}\t{{.State}}\t{{.Health}}" 2>/dev/null || true
+        fi
+    done
+
+    log_error "Services not healthy after ${timeout}s"
+    docker compose $compose_files ps --format "table {{.Name}}\t{{.State}}\t{{.Health}}" 2>/dev/null || true
+    return 1
+}
+
+# Check if a container is running
+# Usage: is_container_running <container_name>
+is_container_running() {
+    local container_name="$1"
+    local status
+    status=$(docker inspect --format='{{.State.Status}}' "$container_name" 2>/dev/null || echo "missing")
+
+    if [ "$status" = "running" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Get container logs for debugging
+# Usage: get_container_logs <container_name> [lines]
+get_container_logs() {
+    local container_name="$1"
+    local lines="${2:-100}"
+
+    if ! docker inspect "$container_name" >/dev/null 2>&1; then
+        echo "Container $container_name not found"
+        return 1
+    fi
+
+    docker logs --tail "$lines" "$container_name" 2>&1
+}
+
+# Docker Compose cleanup helper
+# Usage: cleanup_docker_compose <compose_dir>
+cleanup_docker_compose() {
+    local compose_dir="$1"
+    local compose_files=""
+
+    if [ -f "$compose_dir/docker-compose.yml" ] && [ -f "$compose_dir/docker-compose.test.yml" ]; then
+        compose_files="-f $compose_dir/docker-compose.yml -f $compose_dir/docker-compose.test.yml"
+    elif [ -f "$compose_dir/docker-compose.yml" ]; then
+        compose_files="-f $compose_dir/docker-compose.yml"
+    else
+        log_warn "No docker-compose.yml found in $compose_dir"
+        return 1
+    fi
+
+    log_info "Cleaning up Docker Compose: $compose_dir"
+    docker compose $compose_files down -v 2>/dev/null || true
+    log_success "Docker Compose cleanup complete"
+}

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -9,8 +9,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 # Load configuration
+# Preserve BACKEND_URL if already set (for Docker test runs)
+_preserved_backend_url="${BACKEND_URL:-}"
+_preserved_backend_ws_url="${BACKEND_WS_URL:-}"
 source config.env
 source lib/utils.sh
+# Restore BACKEND_URL if it was set before sourcing config.env
+if [ -n "$_preserved_backend_url" ]; then
+    export BACKEND_URL="$_preserved_backend_url"
+fi
+if [ -n "$_preserved_backend_ws_url" ]; then
+    export BACKEND_WS_URL="$_preserved_backend_ws_url"
+fi
 
 # Test suites in execution order
 TEST_SUITES=(

--- a/tests/run-docker-tests.sh
+++ b/tests/run-docker-tests.sh
@@ -1,0 +1,480 @@
+#!/bin/bash
+#
+# Catalyst Docker E2E Test Orchestrator
+# Builds local Docker images and runs the full E2E test suite in containers.
+#
+# Usage:
+#   ./run-docker-tests.sh [OPTIONS]
+#
+# Options:
+#   --skip-build          Skip image building (use existing)
+#   --skip-cleanup        Don't cleanup containers after tests
+#   --suite <name>        Run specific test suite only
+#   --stop-on-failure     Stop on first test failure
+#   --verbose             Show all test output
+#   --logs-dir <path>     Custom logs directory (default: /tmp/catalyst-docker-tests)
+#   --help                Show help message
+#
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CATALYST_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCKER_DIR="$CATALYST_ROOT/catalyst-docker"
+TEST_ENV_FILE="$DOCKER_DIR/.env.test"
+COMPOSE_FILES="-f $DOCKER_DIR/docker-compose.yml -f $DOCKER_DIR/docker-compose.test.yml"
+
+# Default settings
+SKIP_BUILD=false
+SKIP_CLEANUP=false
+SUITE=""
+STOP_ON_FAILURE=false
+VERBOSE=false
+LOGS_DIR="/tmp/catalyst-docker-tests"
+
+# Tracking
+TEST_EXIT_CODE=0
+BUILD_START_TIME=0
+BUILD_END_TIME=0
+ENV_START_TIME=0
+ENV_END_TIME=0
+TEST_START_TIME=0
+TEST_END_TIME=0
+
+# ============================================================================
+# Load Libraries
+# ============================================================================
+
+source "$SCRIPT_DIR/lib/utils.sh"
+source "$SCRIPT_DIR/lib/docker-env.sh"
+
+# ============================================================================
+# CLI Argument Parsing
+# ============================================================================
+
+parse_arguments() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --skip-build)
+                SKIP_BUILD=true
+                shift
+                ;;
+            --skip-cleanup)
+                SKIP_CLEANUP=true
+                shift
+                ;;
+            --suite)
+                if [[ -z "${2:-}" ]]; then
+                    log_error "--suite requires a test file name"
+                    exit 1
+                fi
+                SUITE="$2"
+                shift 2
+                ;;
+            --stop-on-failure)
+                STOP_ON_FAILURE=true
+                shift
+                ;;
+            --verbose)
+                VERBOSE=true
+                shift
+                ;;
+            --logs-dir)
+                LOGS_DIR="$2"
+                shift 2
+                ;;
+            --help|-h)
+                show_help
+                exit 0
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+}
+
+show_help() {
+    cat <<EOF
+Catalyst Docker E2E Test Orchestrator
+
+Usage: $(basename "$0") [OPTIONS]
+
+Builds local Docker images and runs the E2E test suite against containerized
+Catalyst services (auth, templates, settings, nodes, etc.).
+
+Options:
+  --skip-build          Skip image building (use existing images)
+  --skip-cleanup        Don't cleanup containers after tests
+  --suite <name>        Run specific test suite only (e.g., 01-auth.test.sh)
+  --stop-on-failure     Stop on first test failure
+  --verbose             Show all test output (not just failures)
+  --logs-dir <path>     Custom logs directory (default: /tmp/catalyst-docker-tests)
+  --help, -h            Show this help message
+
+Examples:
+  # Run full test suite
+  ./run-docker-tests.sh
+
+  # Run with verbose output
+  ./run-docker-tests.sh --verbose
+
+  # Run single suite, skip build
+  ./run-docker-tests.sh --suite 01-auth.test.sh --skip-build
+
+  # Run and keep containers for debugging
+  ./run-docker-tests.sh --skip-cleanup
+
+Environment Variables:
+  TEST_LOG_DIR          Where logs are saved (overrides --logs-dir)
+  BACKEND_URL           Auto-set by the orchestrator
+  BACKEND_WS_URL        Auto-set by the orchestrator
+
+Notes:
+  - Agent image build is optional; some test suites will be skipped if unavailable
+EOF
+}
+
+# ============================================================================
+# Logging Setup
+# ============================================================================
+
+setup_logging() {
+    # Use environment variable if set, otherwise CLI argument
+    LOGS_DIR="${TEST_LOG_DIR:-$LOGS_DIR}"
+
+    mkdir -p "$LOGS_DIR"
+
+    # Create a main orchestrator log
+    ORCHESTRATOR_LOG="$LOGS_DIR/orchestrator.log"
+
+    log_info "Logs directory: $LOGS_DIR"
+    log_info "Orchestrator log: $ORCHESTRATOR_LOG"
+
+    # Redirect all output to both console and log file
+    exec > >(tee -a "$ORCHESTRATOR_LOG")
+    exec 2> >(tee -a "$ORCHESTRATOR_LOG" >&2)
+}
+
+# ============================================================================
+# Phase 1: Build Images
+# ============================================================================
+
+build_images() {
+    if $SKIP_BUILD; then
+        log_section "Phase 1: Building Docker Images (SKIPPED)"
+        log_info "Using existing images"
+        return 0
+    fi
+
+    log_section "Phase 1: Building Docker Images"
+    BUILD_START_TIME=$(date +%s)
+
+    cd "$DOCKER_DIR"
+
+    # Ensure .env.test exists for build context
+    if [ ! -f "$TEST_ENV_FILE" ]; then
+        log_warn "No .env.test found, will generate after environment setup"
+    fi
+
+    # Build backend image
+    log_info "Building backend image..."
+    docker compose $COMPOSE_FILES build backend \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        2>&1 | tee "$LOGS_DIR/build-backend.log"
+    log_success "Backend image built: catalyst-backend:test"
+
+    # Build frontend image
+    log_info "Building frontend image..."
+    docker compose $COMPOSE_FILES build frontend \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        2>&1 | tee "$LOGS_DIR/build-frontend.log"
+    log_success "Frontend image built: catalyst-frontend:test"
+
+    # Optionally build agent image
+    log_info "Building agent image..."
+    docker compose $COMPOSE_FILES build agent \
+        --build-arg BUILDKIT_INLINE_CACHE=1 \
+        2>&1 | tee "$LOGS_DIR/build-agent.log" || {
+        log_warn "Agent image build failed (optional, some tests may be skipped)"
+    }
+
+    BUILD_END_TIME=$(date +%s)
+    local duration=$((BUILD_END_TIME - BUILD_START_TIME))
+    log_success "Image builds completed in ${duration}s"
+}
+
+# ============================================================================
+# Phase 2: Setup Environment
+# ============================================================================
+
+setup_environment() {
+    log_section "Phase 2: Setting Up Test Environment"
+    ENV_START_TIME=$(date +%s)
+
+    cd "$DOCKER_DIR"
+
+    # Generate test environment
+    log_info "Generating test environment..."
+    generate_test_env "$TEST_ENV_FILE"
+
+    # Load the environment variables
+    load_test_env "$TEST_ENV_FILE"
+
+    # Export URLs for test scripts
+    export BACKEND_URL
+    BACKEND_URL=$(get_test_backend_url "$TEST_ENV_FILE")
+    export BACKEND_URL
+
+    export BACKEND_WS_URL
+    BACKEND_WS_URL=$(get_test_ws_url "$TEST_ENV_FILE")
+    export BACKEND_WS_URL
+
+    export FRONTEND_URL
+    FRONTEND_URL=$(get_test_frontend_url "$TEST_ENV_FILE")
+    export FRONTEND_URL
+
+    log_info "Backend URL: $BACKEND_URL"
+    log_info "Frontend URL: $FRONTEND_URL"
+    log_info "WebSocket URL: $BACKEND_WS_URL"
+
+    # Stop any existing test containers
+    log_info "Stopping any existing test containers..."
+    docker compose $COMPOSE_FILES --env-file "$TEST_ENV_FILE" down -v 2>/dev/null || true
+
+    # Start services
+    log_info "Starting Docker Compose services..."
+    docker compose $COMPOSE_FILES --env-file "$TEST_ENV_FILE" up -d
+
+    # Wait for services to be healthy
+    log_info "Waiting for services to be healthy..."
+    if ! wait_for_compose_services "$DOCKER_DIR" 120; then
+        log_error "Services failed to become healthy"
+        capture_container_logs
+        return 1
+    fi
+
+    # Wait for backend /health endpoint
+    log_info "Waiting for backend /health endpoint..."
+    if ! wait_for_service "${BACKEND_URL}/health" 60; then
+        log_error "Backend health endpoint not responding"
+        capture_container_logs
+        return 1
+    fi
+
+    # Run database migrations
+    log_info "Running database migrations..."
+    if ! run_db_migrations; then
+        log_error "Database migrations failed"
+        capture_container_logs
+        return 1
+    fi
+
+    ENV_END_TIME=$(date +%s)
+    local duration=$((ENV_END_TIME - ENV_START_TIME))
+    log_success "Test environment ready in ${duration}s"
+}
+
+# Run database migrations inside the backend container
+run_db_migrations() {
+    local backend_container
+    backend_container=$(docker compose $COMPOSE_FILES --env-file "$TEST_ENV_FILE" ps -q backend)
+
+    if [ -z "$backend_container" ]; then
+        log_error "Backend container not found"
+        return 1
+    fi
+
+    # Wait a moment for postgres to be fully ready
+    sleep 2
+
+    # Run db:push with force-reset for clean test state
+    docker exec "$backend_container" sh -c \
+        "cd /app && bun run db:push --force-reset" 2>&1 | tee "$LOGS_DIR/db-migration.log"
+
+    local exit_code=${PIPESTATUS[0]}
+    if [ $exit_code -ne 0 ]; then
+        log_error "Database push failed with exit code $exit_code"
+        return 1
+    fi
+
+    # Seed the database
+    log_info "Seeding database..."
+    docker exec "$backend_container" sh -c \
+        "cd /app && bun run db:seed" 2>&1 | tee "$LOGS_DIR/db-seed.log"
+
+    exit_code=${PIPESTATUS[0]}
+    if [ $exit_code -ne 0 ]; then
+        log_warn "Database seed failed with exit code $exit_code (continuing)"
+        # Don't fail on seed — tests may create their own data
+    fi
+
+    log_success "Database migrations complete"
+    return 0
+}
+
+# Capture container logs for debugging
+capture_container_logs() {
+    log_info "Capturing container logs..."
+    local services=("backend" "frontend" "postgres" "redis")
+    for service in "${services[@]}"; do
+        get_container_logs "catalyst-${service}-test" 500 > "$LOGS_DIR/${service}-logs.txt" 2>&1 || true
+    done
+}
+
+# ============================================================================
+# Phase 3: Run Tests
+# ============================================================================
+
+run_tests() {
+    log_section "Phase 3: Running E2E Tests"
+    TEST_START_TIME=$(date +%s)
+
+    cd "$SCRIPT_DIR"
+
+    # Build arguments for run-all-tests.sh
+    local test_args=()
+
+    if [ -n "$SUITE" ]; then
+        test_args+=("--suite" "$SUITE")
+    fi
+
+    if $STOP_ON_FAILURE; then
+        test_args+=("--stop-on-failure")
+    fi
+
+    if $VERBOSE; then
+        test_args+=("--verbose")
+    fi
+
+    # Set TEST_LOG_DIR for test suites
+    export TEST_LOG_DIR="$LOGS_DIR"
+    mkdir -p "$TEST_LOG_DIR"
+
+    log_info "Running test suites with BACKEND_URL=$BACKEND_URL"
+    log_info "Test arguments: ${test_args[*]:-<none>}"
+
+    # Run the test suite
+    set +e
+    bash "$SCRIPT_DIR/run-all-tests.sh" "${test_args[@]}"
+    TEST_EXIT_CODE=$?
+    set -e
+
+    TEST_END_TIME=$(date +%s)
+    local duration=$((TEST_END_TIME - TEST_START_TIME))
+
+    if [ $TEST_EXIT_CODE -eq 0 ]; then
+        log_success "All tests passed in ${duration}s"
+    else
+        log_error "Tests failed with exit code $TEST_EXIT_CODE (duration: ${duration}s)"
+    fi
+}
+
+# ============================================================================
+# Cleanup
+# ============================================================================
+
+cleanup() {
+    log_section "Cleanup"
+
+    if $SKIP_CLEANUP; then
+        log_info "Skipping cleanup (--skip-cleanup)"
+        log_info "Containers are still running for inspection:"
+        docker compose $COMPOSE_FILES --env-file "$TEST_ENV_FILE" ps 2>/dev/null || true
+        log_info "To clean up manually:"
+        log_info "  cd $DOCKER_DIR && docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test down -v"
+        return 0
+    fi
+
+    log_info "Stopping and removing test containers..."
+    cd "$DOCKER_DIR"
+    docker compose $COMPOSE_FILES --env-file "$TEST_ENV_FILE" down -v 2>&1 | tee "$LOGS_DIR/cleanup.log" || true
+
+    log_info "Removing test images..."
+    docker rmi catalyst-backend:test catalyst-frontend:test catalyst-agent:test 2>/dev/null || true
+
+    log_info "Removing test environment file..."
+    rm -f "$TEST_ENV_FILE"
+
+    log_success "Cleanup complete"
+}
+
+# ============================================================================
+# Main Execution
+# ============================================================================
+
+main() {
+    parse_arguments "$@"
+
+    print_header "CATALYST DOCKER E2E TEST ORCHESTRATOR"
+
+    setup_logging
+
+    log_info "Starting Docker E2E tests at $(date)"
+    log_info "Skip build: $SKIP_BUILD"
+    log_info "Skip cleanup: $SKIP_CLEANUP"
+    log_info "Suite: ${SUITE:-<all>}"
+    log_info "Stop on failure: $STOP_ON_FAILURE"
+    log_info "Verbose: $VERBOSE"
+    log_info "Logs directory: $LOGS_DIR"
+
+    # Check prerequisites
+    log_section "Prerequisite Checks"
+    if ! check_docker_prerequisites; then
+        log_error "Prerequisites not met. Exiting."
+        exit 1
+    fi
+
+    # Run phases
+    build_images
+    setup_environment
+    run_tests
+
+    # Final cleanup (unless skipped)
+    cleanup
+
+    # Print summary
+    log_section "Test Execution Summary"
+
+    local total_duration=$((TEST_END_TIME - BUILD_START_TIME))
+    local build_duration=$((BUILD_END_TIME - BUILD_START_TIME))
+    local env_duration=$((ENV_END_TIME - ENV_START_TIME))
+    local test_duration=$((TEST_END_TIME - TEST_START_TIME))
+
+    echo ""
+    echo -e "${BOLD}${CYAN}╔════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BOLD}${CYAN}║                 DOCKER E2E TEST SUMMARY                    ║${NC}"
+    echo -e "${BOLD}${CYAN}╚════════════════════════════════════════════════════════════╝${NC}"
+    echo ""
+    echo -e "  Build time:    ${build_duration}s"
+    echo -e "  Env setup:     ${env_duration}s"
+    echo -e "  Test time:     ${test_duration}s"
+    echo -e "  Total:         ${total_duration}s"
+    echo ""
+    echo -e "  Logs:          $LOGS_DIR"
+    echo ""
+
+    if [ $TEST_EXIT_CODE -eq 0 ]; then
+        echo -e "${BOLD}${GREEN}╔════════════════════════════════════════════════════════════╗${NC}"
+        echo -e "${BOLD}${GREEN}║               ✓ ALL DOCKER E2E TESTS PASSED                ║${NC}"
+        echo -e "${BOLD}${GREEN}╚════════════════════════════════════════════════════════════╝${NC}"
+    else
+        echo -e "${BOLD}${RED}╔════════════════════════════════════════════════════════════╗${NC}"
+        echo -e "${BOLD}${RED}║               ✗ SOME DOCKER E2E TESTS FAILED               ║${NC}"
+        echo -e "${BOLD}${RED}╚════════════════════════════════════════════════════════════╝${NC}"
+        echo ""
+        echo -e "  Check logs: $LOGS_DIR"
+    fi
+    echo ""
+
+    exit $TEST_EXIT_CODE
+}
+
+# Run main with all arguments
+main "$@"


### PR DESCRIPTION
Closes #117

## Summary
Implements automated Docker container testing that builds local images and runs comprehensive E2E tests against containerized services.

## What's New

### Main Orchestrator: `run-docker-tests.sh`
A CLI-driven test orchestrator with:
- **--skip-build** — Use existing images (faster iteration)
- **--skip-cleanup** — Keep containers for debugging
- **--suite <name>** — Run specific test suite
- **--stop-on-failure** — Fail fast mode
- **--verbose** — Full test output
- **--logs-dir <path>** — Custom log location

### Test Environment: `docker-env.sh`
Generates isolated test environments with:
- Randomized ports (20000-60000 range)
- Auto-generated secrets (auth, DB, Redis)
- Fresh SFTP host keys per run
- Complete .env.test file generation

### CI/CD Integration
GitHub Actions workflow (`.github/workflows/docker-e2e.yml`) runs on:
- PRs to `main` or `develop` (when relevant files change)
- Pushes to `main`

Features artifact uploads, container logs on failure, and proper cleanup.

## Test Coverage
| Feature | Test Suite |
|---------|------------|
| Authentication | 01-auth.test.sh |
| Templates | 02-templates.test.sh |
| Nodes | 03-nodes.test.sh |
| Settings/Permissions | 05-permissions.test.sh |
| + 10 more E2E suites | |

## Usage

### Quick Start
```bash
cd tests
./run-docker-tests.sh
```

### Run Single Suite
```bash
./run-docker-tests.sh --suite 01-auth.test.sh --verbose
```

### Debug Mode (keep containers)
```bash
./run-docker-tests.sh --skip-cleanup
# Inspect after failure:
docker compose -f docker-compose.yml -f docker-compose.test.yml --env-file .env.test logs
```

## Files Added/Modified
- `tests/run-docker-tests.sh` — Main orchestrator (NEW)
- `tests/lib/docker-env.sh` — Environment generator (NEW)
- `tests/DOCKER_TESTING.md` — Documentation (NEW)
- `.github/workflows/docker-e2e.yml` — CI workflow (NEW)
- `catalyst-docker/docker-compose.test.yml` — Test Compose config (NEW)
- `tests/lib/utils.sh` — Docker helper functions (+100 lines)
- `tests/run-all-tests.sh` — Preserve BACKEND_URL for Docker runs

## Testing
- All bash scripts pass `bash -n` syntax validation
- YAML files pass schema validation
- CLI `--help` displays correctly
- Successfully builds and tests against local Docker images

## Documentation
See `tests/DOCKER_TESTING.md` for:
- Architecture diagram
- Full CLI reference
- Troubleshooting guide
- Development tips


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Introduced Docker-based end-to-end testing infrastructure for local and CI/CD environments.
  * Supports multiple test suites with configurable options including skip build, stop on failure, and verbose modes.
  * Includes automated environment setup, service health checks, and database migrations.

* **Documentation**
  * Added comprehensive Docker testing guide covering setup, architecture, and troubleshooting.

* **Chores**
  * Integrated E2E testing into GitHub Actions CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->